### PR TITLE
Creates a unique activity feed conversation that is stored apart from the application's basic conversations.

### DIFF
--- a/src/main/java/codeu/controller/ServerStartupListener.java
+++ b/src/main/java/codeu/controller/ServerStartupListener.java
@@ -12,6 +12,9 @@ import java.util.List;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import java.time.Instant;
+import java.util.UUID;
+
 /**
  * Listener class that fires when the server first starts up, before any servlet classes are
  * instantiated.
@@ -27,6 +30,21 @@ public class ServerStartupListener implements ServletContextListener {
 
       List<Conversation> conversations = PersistentStorageAgent.getInstance().loadConversations();
       ConversationStore.getInstance().setConversations(conversations);
+
+			Conversation actFeedConversation = PersistentStorageAgent.getInstance().loadActFeedConversation();
+			ConversationStore.getInstance().setActFeedConversation(actFeedConversation);
+			
+			/**
+			 * Checks to see if the actFeedConversation has been set in datastore yet.
+			 * If not, creates a new activityFeedConversation and writes it through to datastore.
+			 * Should only ever happen one time.
+			 */
+
+			if (ConversationStore.getInstance().getActFeedConversation().getId() == null ) {
+				Conversation convo = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "actFeedConversation", Instant.now());
+				ConversationStore.getInstance().setActFeedConversation(convo);
+				PersistentStorageAgent.getInstance().actFeedWriteThrough(convo);
+			}
 
       List<Message> messages = PersistentStorageAgent.getInstance().loadMessages();
       MessageStore.getInstance().setMessages(messages);

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -57,6 +57,9 @@ public class ConversationStore {
 
   /** The in-memory list of Conversations. */
   private List<Conversation> conversations;
+	
+	/** The in-memory activity feed conversation. */
+	private Conversation actFeedConversation;
 
   /** This class is a singleton, so its constructor is private. Call getInstance() instead. */
   private ConversationStore(PersistentStorageAgent persistentStorageAgent) {
@@ -64,10 +67,16 @@ public class ConversationStore {
     conversations = new ArrayList<>();
   }
 
-/** Access the current set of conversations known to the application. */
+	/** Access the current set of conversations known to the application. */
   public List<Conversation> getAllConversations() {
     return conversations;
   }
+	
+	/** Access the activity feed conversation known to the application. */
+  public Conversation getActFeedConversation() {
+    return actFeedConversation;
+  }
+
 
   /** Add a new conversation to the current set of conversations known to the application. */
   public void addConversation(Conversation conversation) {
@@ -107,4 +116,10 @@ public class ConversationStore {
   public void setConversations(List<Conversation> conversations) {
     this.conversations = conversations;
   }
+
+	/** Sets the activity feed conversation stored by this ConversationStore. */
+	public void setActFeedConversation(Conversation actFeedConversation) {
+		this.actFeedConversation = actFeedConversation;
+	}
+
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -79,6 +79,17 @@ public class PersistentStorageAgent {
     return persistentDataStore.loadConversations();
   }
 
+	/**
+	 * Retrieve the Activity Feed's conversation object from the Datastore service.
+	 *
+	 *@throws PersistentDataStoreException if an error was detected during the load from the 
+	 *	Datastore service 
+   */
+
+	public Conversation loadActFeedConversation() throws PersistentDataStoreException {
+		return persistentDataStore.loadActFeedConversation();
+	}
+
   /**
    * Retrieve all Message objects from the Datastore service. The returned list may be empty.
    *
@@ -102,5 +113,10 @@ public class PersistentStorageAgent {
   /** Write a Conversation object to the Datastore service. */
   public void writeThrough(Message message) {
     persistentDataStore.writeThrough(message);
+  }
+
+	/** Write an activity feed Conversation object to the Datastore service. */
+	public void actFeedWriteThrough(Conversation conversation) {
+    persistentDataStore.actFeedWriteThrough(conversation);
   }
 }


### PR DESCRIPTION
*PersistentDataStore.java
--Added methods to retrieve/"writeThrough" the activity feed conversation from/to datastore
*PersistentStorageAgent.java
--Added methods to handle" writingThrough" to and retrieving from datastore
*ConversationStore.java
--Added a new attribute to ConversationStore class that holds the activity feed conversation
--Added accessor method to retrieve activity feed conversation
--Wrote mutator method to set activity feed conversation attribute
*ServerStartupListener
--sets the activityfeed attribute in conversationStore equal to activityfeed conversation saved in datastore
--If there is no activityfeed conversation currently stored in datastore, it will create a new activityfeed conversation and write it through to datastore (should only ever happen once)