### PR TITLE
Admin users can now register new admins

### DIFF
--- a/src/main/java/codeu/controller/AdminServlet.java
+++ b/src/main/java/codeu/controller/AdminServlet.java
@@ -71,8 +71,7 @@ public class AdminServlet extends HttpServlet {
       return;
     }
 
-    if(user.getName().matches("aaron") || user.getName().matches("pbonds") ||
-       user.getName().matches("anitacu")){
+    if(user.isAdmin()){
       // user is in admin list, give access to admin site
       request.getRequestDispatcher("/WEB-INF/view/admin.jsp").forward(request, response);
       return;

--- a/src/main/java/codeu/controller/ServerStartupListener.java
+++ b/src/main/java/codeu/controller/ServerStartupListener.java
@@ -12,6 +12,8 @@ import java.util.List;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import org.mindrot.jbcrypt.BCrypt;
+
 import java.time.Instant;
 import java.util.UUID;
 
@@ -33,7 +35,7 @@ public class ServerStartupListener implements ServletContextListener {
 
 			Conversation actFeedConversation = PersistentStorageAgent.getInstance().loadActFeedConversation();
 			ConversationStore.getInstance().setActFeedConversation(actFeedConversation);
-			
+
 			/**
 			 * Checks to see if the actFeedConversation has been set in datastore yet.
 			 * If not, creates a new activityFeedConversation and writes it through to datastore.
@@ -45,6 +47,16 @@ public class ServerStartupListener implements ServletContextListener {
 				ConversationStore.getInstance().setActFeedConversation(convo);
 				PersistentStorageAgent.getInstance().actFeedWriteThrough(convo);
 			}
+
+      UserStore userStore = UserStore.getInstance();
+      String username = "admin";
+      /** Check if admin exists, if not create it */
+      if(!userStore.isUserRegistered(username)){
+        String password = "admin";
+        String hashedPassword = BCrypt.hashpw(password, BCrypt.gensalt());
+        User user = new User(UUID.randomUUID(), username, hashedPassword, Instant.now(), true);
+        userStore.addUser(user);
+      }
 
       List<Message> messages = PersistentStorageAgent.getInstance().loadMessages();
       MessageStore.getInstance().setMessages(messages);

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -78,4 +78,9 @@ public class User {
     return admin;
   }
 
+  /** Set admin attribute */
+  public void setAdmin(Boolean admin){
+    this.admin = admin;
+  }
+
 }

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -54,6 +54,12 @@ Integer messageSize = messageStore.countTotalMessages();
 
     <p>New features coming soon...</p>
 
+    <form action="/admin" method="POST">
+        <p> <b>Make someone admin:<b> </p>
+        <input type="text" name="toBeAdminUser" value="" placeholder="username" >
+        <br/>
+        <button type="submit">Submit</button>
+    </form>
 
   </div>
 </body>

--- a/src/main/webapp/WEB-INF/view/admin.jsp
+++ b/src/main/webapp/WEB-INF/view/admin.jsp
@@ -61,6 +61,12 @@ Integer messageSize = messageStore.countTotalMessages();
         <button type="submit">Submit</button>
     </form>
 
+    <% if(request.getAttribute("error") != null){ %>
+        <h2 style="color:red"><%= request.getAttribute("error") %></h2>
+    <% } else if(request.getAttribute("success") != null){%>
+        <h2 style="color:green"><%= request.getAttribute("success") %></h2>
+    <% } %>
+
   </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/view/navbar.jsp
+++ b/src/main/webapp/WEB-INF/view/navbar.jsp
@@ -1,15 +1,24 @@
 <%-- This navbar has the added functionality of linking a user to their profile page
 once they are logged in and adds a link to the site's activity feed --%>
 
+<%@ page import="codeu.model.store.basic.UserStore" %>
+<%@ page import="codeu.model.data.User" %>
+
 <nav>
-	<% String user = (String) request.getSession().getAttribute("user"); %>
+	<%
+	String username = (String) request.getSession().getAttribute("user");
+	User user = UserStore.getInstance().getUser(username);
+	%>
 	<a id="navTitle" href="/">CodeU Chat App</a>
 	<a href="/conversations">Conversations</a>
-	<% if(user != null) { %>
-		<a href="/users/<%= user %>" > <%= user %> profile</a>
+	<% if(username != null) { %>
+		<a href="/users/<%= username %>" > <%= username %> profile</a>
 	<% } else { %>
 		<a href="/login">Login</a>
 	<% } %>
 	<a href="/about.jsp">About</a>
 	<a href="/activityfeed">ActivityFeed</a>
+	<% if(user != null && user.isAdmin()) {%>
+		<a href="/admin" > Admin Page</a>
+	<% } %>
 </nav>


### PR DESCRIPTION
- Create admin username on startup automatically :godmode: 
- `If(user.isAdmin())` he can see Admin Page href in navbar.
- Admin users can now register new admins! :octocat: 
- After trying to register an admin, prints message.
- Added `setAdmin()` method in User class.

![success](https://user-images.githubusercontent.com/20996397/40599203-a6948a00-6211-11e8-90c2-097eb196c2b5.png)
![noexist](https://user-images.githubusercontent.com/20996397/40599204-a6cb0f1c-6211-11e8-82a8-6c6e44646090.png)
![alreadyadmin](https://user-images.githubusercontent.com/20996397/40599205-a6dd0046-6211-11e8-9023-37f6c8f2b907.png)
