### PR TITLE
Created an ActivityStore class to hold Activity objects, minor updates to Activity class

### DIFF
--- a/src/main/java/codeu/model/data/Activity.java
+++ b/src/main/java/codeu/model/data/Activity.java
@@ -31,6 +31,13 @@ public class Activity {
 	private final UUID userId;
 	private final String username;
 	
+	/** 
+	 * Declares whether it is an activity object for a conversation or for a user registration 
+	 * 'C' is used for a conversation while 'R' is used for a registration. 
+	 * May eventually be changed to an enum.
+	 */
+	private final char type;
+	
 	/**
 	 * Constructs a new Activity.
 	 *
@@ -42,13 +49,14 @@ public class Activity {
 	 * @param 
 	 */
 	
-	public Activity(UUID activityId, Instant creation, String message, UUID userId, String username) {
+	public Activity(UUID activityId, Instant creation, String message, UUID userId, String username, char type) {
 		this.activityId = activityId;
 		this.allTimeCount = 0;
 		this.creation = creation;
 		this.message = message;
 		this.userId = userId;
 		this.username = username;
+		this.type = type;
 	}
 	
 	/** Returns the ID of this activity. */
@@ -79,6 +87,11 @@ public class Activity {
 	/** Returns the username of the user associated with the activity */
 	public String getUsername() {
 		return username;
+	}
+
+	/** Returns the type of activity **/
+	public char getType() {
+		return type;
 	}
 	
 	public void increaseAllTimeCount() {

--- a/src/main/java/codeu/model/store/basic/ActivityStore.java
+++ b/src/main/java/codeu/model/store/basic/ActivityStore.java
@@ -1,0 +1,76 @@
+package codeu.model.store.basic;
+
+import codeu.model.data.Activity;
+import codeu.model.store.persistence.PersistentStorageAgent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Store class that uses in-memory data structures to hold values and automatically loads from
+ * and saves to PersistentStorageAgent. It's a singleton so all servlet classes can access
+ * the same instance.
+ */
+
+public class ActivityStore {
+
+	/** Singleton instance of ActivityStore. */
+	private static ActivityStore instance;
+	
+	/**
+	 * Returns the singleton instance of ActivityStore that should be shared between all
+	 * servlet classes. Do not call this function from a test; use getTestInstance() instead.
+	 */
+	public static ActivityStore getInstance() {
+		if (instance == null) {
+			instance = new ActivityStore(PersistentStorageAgent.getInstance());		
+		}
+		return instance;
+	}
+
+	/**
+	 * Instance getter function used for testing. Supply a mock for PersistentStorageAgent.
+	 *
+	 * @param persistentStorageAgent a mock used for testing
+	 */
+	public static ActivityStore getTestInstance(PersistentStorageAgent persistentStorageAgent) {
+		return new ActivityStore(persistentStorageAgent);	
+	}
+	
+	/**
+	 * The PersistentStorageAgent responsible for loading Activities from and saving Activities
+	 * to Datastore.
+	 */
+	private PersistentStorageAgent persistentStorageAgent;
+
+	/** The in-memory list of Activities. */
+	private List<Activity> activities;
+
+	/** This class is a singleton, so its constructor is private. Call getInstance() instead. */
+	private ActivityStore(PersistentStorageAgent persistentStorageAgent) {
+		this.persistentStorageAgent = persistentStorageAgent;
+		activities = new ArrayList<>();
+	}
+
+	/** Add a new activity to the current set of activities known to the application. */
+	public void addActivity(Activity activity) {
+		activities.add(activity);
+		//persistentStorageAgent.writeThrough(activity);
+	}
+
+	/** Find and return the Activity with the given Id, mainly used for testing. */
+	public Activity getActivityWithId(UUID id) {
+		for (Activity activity : activities) {
+			if(activity.getActivityId().equals(id)) {
+				return activity;			
+			}
+		}
+		return null;
+	}
+
+	/** Sets the List of Activities stored by this ActivityStore. */
+	public void setActivities(List<Activity> activities) {
+		this.activities = activities;
+	}
+
+}

--- a/src/test/java/codeu/model/data/ActivityTest.java
+++ b/src/test/java/codeu/model/data/ActivityTest.java
@@ -14,14 +14,20 @@ public class ActivityTest {
 		String message = "Test_Message";
 		UUID userId = UUID.randomUUID();
 		String username = "Test_Username";
+		char type = 'T';
 
-		Activity activity = new Activity(activityId, creation, message, userId, username);
+		Activity activity = new Activity(activityId, creation, message, userId, username, type);
 
 		Assert.assertEquals(activityId, activity.getActivityId());
+		
 		Assert.assertEquals(0, activity.getAllTimeCount());
+		activity.increaseAllTimeCount();
+		Assert.assertEquals(1, activity.getAllTimeCount());
+		
 		Assert.assertEquals(creation, activity.getCreationTime());
 		Assert.assertEquals(message, activity.getMessage());
 		Assert.assertEquals(userId, activity.getUserId());
 		Assert.assertEquals(username, activity.getUsername());
+		Assert.assertEquals(type, activity.getType());
   }
 }

--- a/src/test/java/codeu/model/store/basic/ActivityStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ActivityStoreTest.java
@@ -1,0 +1,67 @@
+package codeu.model.store.basic;
+
+import codeu.model.data.Activity;
+import codeu.model.store.persistence.PersistentStorageAgent;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ActivityStoreTest {
+	private ActivityStore activityStore;
+	private PersistentStorageAgent mockPersistentStorageAgent;
+	private UUID activityId = UUID.randomUUID();
+
+	private final Activity ACTIVITY_ONE = new Activity(activityId, Instant.ofEpochMilli(1000), "activity_one", UUID.randomUUID(), "test_user1", 'T');
+
+	@Before
+	public void setup() {
+		mockPersistentStorageAgent = Mockito.mock(PersistentStorageAgent.class);
+		activityStore = activityStore.getTestInstance(mockPersistentStorageAgent);
+
+		final List<Activity> activityList = new ArrayList<>();
+		activityList.add(ACTIVITY_ONE);
+		activityStore.setActivities(activityList);
+	}
+
+	@Test
+	public void testGetActivityWithId_found() {
+		Activity resultActivity = activityStore.getActivityWithId(activityId);
+		
+		assertEquals(ACTIVITY_ONE, resultActivity);
+	}
+
+		@Test
+	public void testGetActivityWithId_notFound() {
+		Activity resultActivity = activityStore.getActivityWithId(UUID.randomUUID());
+		
+		Assert.assertNull(resultActivity);
+	}
+
+	@Test
+	public void testAddActivity() {
+	UUID inputActivityId = UUID.randomUUID();
+	Activity inputActivity = new Activity(inputActivityId, Instant.ofEpochMilli(1000), "activity_two", UUID.randomUUID(), "test_user2", 'T');
+
+		activityStore.addActivity(inputActivity);
+		Activity resultActivity = activityStore.getActivityWithId(inputActivityId);
+
+		assertEquals(inputActivity, resultActivity);
+		//Mockito.verify(mockPersistentStorageAgent).writeThrough(inputConversation); Will be added later
+	}
+
+	private void assertEquals(Activity expectedActivity, Activity actualActivity) {
+		Assert.assertEquals(expectedActivity.getActivityId(), actualActivity.getActivityId());
+		Assert.assertEquals(expectedActivity.getAllTimeCount(), actualActivity.getAllTimeCount());
+		Assert.assertEquals(expectedActivity.getCreationTime(), actualActivity.getCreationTime());
+		Assert.assertEquals(expectedActivity.getMessage(), actualActivity.getMessage());
+		Assert.assertEquals(expectedActivity.getUserId(), actualActivity.getUserId());
+		Assert.assertEquals(expectedActivity.getUsername(), actualActivity.getUsername());
+		Assert.assertEquals(expectedActivity.getType(), actualActivity.getType());
+	}
+	
+}


### PR DESCRIPTION
Creating an activity store class and activity objects will eventually replace the old fashion of saving and loading activity based messages to the activity feed. With this format it will be easier to accomplish tasks that will make the activityfeed more useful and less taxing on memory (loading only the most recent activities, loading the activity of a particular user, loading only a certain amount of activities at a time).
*Updates to Activity Class
--message and allTimeCount member variables changed from 'final' to 'mutable' variables
--Tests for activity class updated to account for extra attribute and new method for increasing allTimeCount
*ActivityStore Class
--Store class that will be used to store activities. Does not write to datastore yet, will be added once PersistentDataStore and persistentDataStoreAgent are modified.
*ActivityStore Class Test
--Tests the activityStore