### PR TITLE
Added direct message feature

### DIFF
--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -114,7 +114,7 @@ public class ConversationServlet extends HttpServlet {
     }
 
     Conversation conversation =
-        new Conversation(UUID.randomUUID(), user.getId(), conversationTitle, Instant.now());
+        new Conversation(UUID.randomUUID(), user.getId(), conversationTitle, Instant.now(), false);
 
     conversationStore.addConversation(conversation);
     response.sendRedirect("/chat/" + conversationTitle);

--- a/src/main/java/codeu/controller/ServerStartupListener.java
+++ b/src/main/java/codeu/controller/ServerStartupListener.java
@@ -43,7 +43,7 @@ public class ServerStartupListener implements ServletContextListener {
 			 */
 
 			if (ConversationStore.getInstance().getActFeedConversation().getId() == null ) {
-				Conversation convo = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "actFeedConversation", Instant.now());
+				Conversation convo = new Conversation(UUID.randomUUID(), UUID.randomUUID(), "actFeedConversation", Instant.now(), false);
 				ConversationStore.getInstance().setActFeedConversation(convo);
 				PersistentStorageAgent.getInstance().actFeedWriteThrough(convo);
 			}

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -28,6 +28,9 @@ public class Conversation {
   public final UUID owner;
   public final Instant creation;
   public final String title;
+  /** This Boolean states whether or not the Conversation is private or not (by default is set to false).
+   * Only true when between two users become pals and want to message each other. */
+  public Boolean privateConversation;
 
   /**
    * Constructs a new Conversation.
@@ -37,11 +40,12 @@ public class Conversation {
    * @param title the title of this Conversation
    * @param creation the creation time of this Conversation
    */
-  public Conversation(UUID id, UUID owner, String title, Instant creation) {
+  public Conversation(UUID id, UUID owner, String title, Instant creation, Boolean privateConvo) {
     this.id = id;
     this.owner = owner;
     this.creation = creation;
     this.title = title;
+    this.privateConversation = privateConvo;
   }
 
   /** Returns the ID of this Conversation. */
@@ -62,6 +66,16 @@ public class Conversation {
   /** Returns the creation time of this Conversation. */
   public Instant getCreationTime() {
     return creation;
+  }
+
+  /** Sets the boolean for this Conversation. */
+  public void setPrivate(Boolean b) {
+    privateConversation = b;
+  }
+
+  /** Returns the boolean stating whether or not this Conversation is private. */
+  public Boolean getPrivate() {
+    return privateConversation;
   }
 
   /** Returns the Instant into a String time format to display to users. */

--- a/src/main/java/codeu/model/data/Conversation.java
+++ b/src/main/java/codeu/model/data/Conversation.java
@@ -68,11 +68,6 @@ public class Conversation {
     return creation;
   }
 
-  /** Sets the boolean for this Conversation. */
-  public void setPrivate(Boolean b) {
-    privateConversation = b;
-  }
-
   /** Returns the boolean stating whether or not this Conversation is private. */
   public Boolean getPrivate() {
     return privateConversation;

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -14,6 +14,11 @@
 
 package codeu.model.data;
 
+import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.ConversationStore;
+import codeu.model.store.persistence.PersistentDataStore;
+
+import java.util.List;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -43,6 +48,7 @@ public class User {
     this.creation = creation;
     setBio(name + " hasn't written a bio yet.");
     this.admin = admin;
+    createConversations();
   }
 
   /** Returns the ID of this User. */
@@ -104,6 +110,36 @@ public class User {
     }
     String date = localDate.getMonth().toString() + " " + localDate.getDayOfMonth() + ", " + localDate.getYear() + " - " + hour + ":" + localDate.getMinute() + " " + timeAMPM;
     return date;
+  }
+
+  /** When a User is initialized, this method creates a private Conversation with every other User that already exists. */
+  public void createConversations() {
+    // get all USers from UserStore
+    // for each User, create a new Conversation with this User and set to private
+    // add all Conversations to ConversationStore
+    // writethrough to DataStore
+    UserStore userStore = UserStore.getInstance();
+    List<User> users = userStore.getUsers();
+    ConversationStore conversationStore = ConversationStore.getInstance();
+    List<Conversation> conversations = conversationStore.getAllConversations();
+
+    for (User u: users) {
+      String otherUserName = u.getName();
+      String firstUser;
+      String secondUser;
+      /** Gets the conversation link by the names of the two users in alphabetical order */
+       if ((this.name).compareTo(otherUserName) < 0) {
+       firstUser = this.name;
+       secondUser = otherUserName;
+       } else {
+       firstUser = otherUserName;
+       secondUser = this.name;
+       }
+       String conversationName = firstUser + secondUser;
+      Conversation c = new Conversation(UUID.randomUUID(), this.id, conversationName, Instant.now(), true);
+      conversationStore.addConversation(c);
+    }
+
   }
 
 }

--- a/src/main/java/codeu/model/store/basic/UserStore.java
+++ b/src/main/java/codeu/model/store/basic/UserStore.java
@@ -143,4 +143,9 @@ public class UserStore {
     int lastUser = users.size()-1;
     return users.get(lastUser);
   }
+
+  /** Returns the list of all Users by this UserStore. */
+  public List<User> getUsers() {
+    return users;
+  }
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -104,7 +104,8 @@ public class PersistentDataStore {
         UUID ownerUuid = UUID.fromString((String) entity.getProperty("owner_uuid"));
         String title = (String) entity.getProperty("title");
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
-        Conversation conversation = new Conversation(uuid, ownerUuid, title, creationTime);
+        Boolean privateConversation = Boolean.parseBoolean((String) entity.getProperty("private_conversation"));
+        Conversation conversation = new Conversation(uuid, ownerUuid, title, creationTime, privateConversation);
         conversations.add(conversation);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
@@ -133,6 +134,7 @@ public class PersistentDataStore {
     UUID ownerUuid = null;
     String title = null;
     Instant creationTime = null;
+    Boolean privateConversation = null;
     Conversation actFeedConversation = null;
 
     for (Entity entity : results.asIterable()) {
@@ -141,7 +143,7 @@ public class PersistentDataStore {
         ownerUuid = UUID.fromString((String) entity.getProperty("owner_uuid"));
         title = (String) entity.getProperty("title");
         creationTime = Instant.parse((String) entity.getProperty("creation_time"));
-
+        privateConversation = Boolean.parseBoolean((String) entity.getProperty("private_conversation"));
 
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
@@ -150,7 +152,8 @@ public class PersistentDataStore {
         throw new PersistentDataStoreException(e);
       }
     }
-    return actFeedConversation = new Conversation(uuid, ownerUuid, title, creationTime);
+    actFeedConversation = new Conversation(uuid, ownerUuid, title, creationTime, privateConversation);
+    return actFeedConversation;
   }
 
   /**
@@ -218,6 +221,7 @@ public class PersistentDataStore {
     conversationEntity.setProperty("owner_uuid", conversation.getOwnerId().toString());
     conversationEntity.setProperty("title", conversation.getTitle());
     conversationEntity.setProperty("creation_time", conversation.getCreationTime().toString());
+    conversationEntity.setProperty("private_conversation", conversation.getPrivate().toString());
     datastore.put(conversationEntity);
   }
 
@@ -231,6 +235,7 @@ public class PersistentDataStore {
     conversationEntity.setProperty("owner_uuid", conversation.getOwnerId().toString());
     conversationEntity.setProperty("title", conversation.getTitle());
     conversationEntity.setProperty("creation_time", conversation.getCreationTime().toString());
+    conversationEntity.setProperty("private_conversation", conversation.getPrivate().toString());
     datastore.put(conversationEntity);
   }
 

--- a/src/main/webapp/WEB-INF/view/conversations.jsp
+++ b/src/main/webapp/WEB-INF/view/conversations.jsp
@@ -61,10 +61,13 @@
       <ul class="mdl-list">
     <%
       for(Conversation conversation : conversations){
+        // only display conversations that are not private
+        if (!conversation.getPrivate()) {
     %>
       <li><a href="/chat/<%= conversation.getTitle() %>">
         <%= conversation.getTitle() %></a></li>
     <%
+        }
       }
     %>
       </ul>

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -36,6 +36,24 @@ UserStore userStore = UserStore.getInstance();
             <h1 style="color:dodgerblue">Welcome to your page!</h1>
         <% } else { %>
             <h1 style="color:dodgerblue">Welcome to <%= profileUser %>'s Page!</h1>
+
+            <%
+            String conversationName = "../chat/";
+            String firstUser;
+            String secondUser;
+            /** Gets the conversation link by the names of the two users in alphabetical order */
+            if (currentUser.compareTo(profileUser) < 0) {
+                firstUser = currentUser;
+                secondUser = profileUser;
+            } else {
+                firstUser = profileUser;
+                secondUser = currentUser;
+            }
+            conversationName = conversationName + firstUser + secondUser;
+            %>
+
+            <a href="/chat/<%= conversationName %>"> View Conversation with <%= profileUser %> </a>
+
         <% } %>
         <% /** Gets the bio of this user to display on their profile page */ %>
             <% String profilePageBio = thisUser.getBio(); %>

--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -24,7 +24,7 @@ body {
 }
 
 nav {
-  background-color: #283593;
+  background-color: #1E90FF;
 }
 
 nav a {
@@ -46,7 +46,7 @@ nav a {
 }
 
 h1 {
-  color: #757575;
+  color: #00BFFF;
 }
 
 input {

--- a/src/test/java/codeu/controller/ActivityFeedServletTest.java
+++ b/src/test/java/codeu/controller/ActivityFeedServletTest.java
@@ -61,7 +61,7 @@ public class ActivityFeedServletTest {
 	
 		UUID fakeConversationId = UUID.randomUUID();
     Conversation fakeConversation =
-        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now(), false);
     Mockito.when(mockConversationStore.getActFeedConversation())
         .thenReturn(fakeConversation);
 		

--- a/src/test/java/codeu/controller/AdminServletTest.java
+++ b/src/test/java/codeu/controller/AdminServletTest.java
@@ -134,7 +134,8 @@ public class AdminServletTest {
                     UUID.randomUUID(),
                     UUID.randomUUID(),
                     "test_conversation",
-                    Instant.now()));
+                    Instant.now(),
+                    false));
 
     Integer userSize = fakeMessageList.size();
     Integer messageSize = fakeMessageList.size();

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -76,7 +76,7 @@ public class ChatServletTest {
 
     UUID fakeConversationId = UUID.randomUUID();
     Conversation fakeConversation =
-        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now(), false);
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
         .thenReturn(fakeConversation);
 
@@ -168,7 +168,7 @@ public class ChatServletTest {
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), false);
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
         .thenReturn(fakeConversation);
 
@@ -198,7 +198,7 @@ public class ChatServletTest {
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), false);
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
         .thenReturn(fakeConversation);
 

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -68,7 +68,7 @@ public class ConversationServletTest {
   public void testDoGet() throws IOException, ServletException {
     List<Conversation> fakeConversationList = new ArrayList<>();
     fakeConversationList.add(
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now()));
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), false));
     Mockito.when(mockConversationStore.getAllConversations()).thenReturn(fakeConversationList);
 
     conversationServlet.doGet(mockRequest, mockResponse);

--- a/src/test/java/codeu/controller/RegisterServletTest.java
+++ b/src/test/java/codeu/controller/RegisterServletTest.java
@@ -81,7 +81,7 @@ public class RegisterServletTest {
 
 				UUID fakeConversationId = UUID.randomUUID();
     Conversation fakeConversation =
-        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(fakeConversationId, UUID.randomUUID(), "test_conversation", Instant.now(), false);
     Mockito.when(mockConversationStore.getActFeedConversation())
         .thenReturn(fakeConversation);
 

--- a/src/test/java/codeu/model/data/ConversationTest.java
+++ b/src/test/java/codeu/model/data/ConversationTest.java
@@ -27,12 +27,14 @@ public class ConversationTest {
     UUID owner = UUID.randomUUID();
     String title = "Test_Title";
     Instant creation = Instant.now();
+    Boolean privateConversation = false;
 
-    Conversation conversation = new Conversation(id, owner, title, creation);
+    Conversation conversation = new Conversation(id, owner, title, creation, privateConversation);
 
     Assert.assertEquals(id, conversation.getId());
     Assert.assertEquals(owner, conversation.getOwnerId());
     Assert.assertEquals(title, conversation.getTitle());
     Assert.assertEquals(creation, conversation.getCreationTime());
+    Assert.assertEquals(privateConversation, conversation.getPrivate());
   }
 }

--- a/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
@@ -18,13 +18,13 @@ public class ConversationStoreTest {
 
   private final Conversation CONVERSATION_ONE =
       new Conversation(
-          UUID.randomUUID(), UUID.randomUUID(), "conversation_one", Instant.ofEpochMilli(1000));
+          UUID.randomUUID(), UUID.randomUUID(), "conversation_one", Instant.ofEpochMilli(1000), false);
   private final Conversation CONVERSATION_TWO =
           new Conversation(
-                  UUID.randomUUID(), UUID.randomUUID(), "conversation_two", Instant.ofEpochMilli(2000));
+                  UUID.randomUUID(), UUID.randomUUID(), "conversation_two", Instant.ofEpochMilli(2000), false);
   private final Conversation CONVERSATION_THREE =
           new Conversation(
-                  UUID.randomUUID(), UUID.randomUUID(), "conversation_three", Instant.ofEpochMilli(3000));
+                  UUID.randomUUID(), UUID.randomUUID(), "conversation_three", Instant.ofEpochMilli(3000), false);
 
   @Before
   public void setup() {
@@ -85,7 +85,7 @@ public class ConversationStoreTest {
   @Test
   public void testAddConversation() {
     Conversation inputConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), false);
 
     conversationStore.addConversation(inputConversation);
     Conversation resultConversation =

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -84,13 +84,15 @@ public class PersistentDataStoreTest {
     UUID ownerOne = UUID.fromString("10000001-2222-3333-4444-555555555555");
     String titleOne = "Test_Title";
     Instant creationOne = Instant.ofEpochMilli(1000);
-    Conversation inputConversationOne = new Conversation(idOne, ownerOne, titleOne, creationOne);
+    Boolean privateConversationOne = false;
+    Conversation inputConversationOne = new Conversation(idOne, ownerOne, titleOne, creationOne, privateConversationOne);
 
     UUID idTwo = UUID.fromString("10000002-2222-3333-4444-555555555555");
     UUID ownerTwo = UUID.fromString("10000003-2222-3333-4444-555555555555");
     String titleTwo = "Test_Title_Two";
     Instant creationTwo = Instant.ofEpochMilli(2000);
-    Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo);
+    Boolean privateConversationTwo = false;
+    Conversation inputConversationTwo = new Conversation(idTwo, ownerTwo, titleTwo, creationTwo, privateConversationTwo);
 
     // save
     persistentDataStore.writeThrough(inputConversationOne);
@@ -105,12 +107,14 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(ownerOne, resultConversationOne.getOwnerId());
     Assert.assertEquals(titleOne, resultConversationOne.getTitle());
     Assert.assertEquals(creationOne, resultConversationOne.getCreationTime());
+    Assert.assertEquals(privateConversationOne, resultConversationOne.getPrivate());
 
     Conversation resultConversationTwo = resultConversations.get(1);
     Assert.assertEquals(idTwo, resultConversationTwo.getId());
     Assert.assertEquals(ownerTwo, resultConversationTwo.getOwnerId());
     Assert.assertEquals(titleTwo, resultConversationTwo.getTitle());
     Assert.assertEquals(creationTwo, resultConversationTwo.getCreationTime());
+    Assert.assertEquals(privateConversationTwo, resultConversationOne.getPrivate());
   }
 
   @Test

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -60,7 +60,7 @@ public class PersistentStorageAgentTest {
   @Test
   public void testWriteThroughConversation() {
     Conversation conversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), false);
     persistentStorageAgent.writeThrough(conversation);
     Mockito.verify(mockPersistentDataStore).writeThrough(conversation);
   }


### PR DESCRIPTION
For the Open Project prototype portion, I wanted to add a direct message feature to everyone's profile page, so if someone clicks in another person's profile page, they can view their conversation with this person. Eventually, I may add the ability for users to add each other as "pals" and once they are pals, they can actually direct message the person. Each user can have a list of pals. However for now, I'll keep it so that everyone can still directly message anyone else.
-profile.jsp: whenever a user is not viewing their own profile page, they are able to see a link that says "View conversation with --whoever's profile page that is--" which links to /chat/user1user2 where user1 is the name that comes first in the alphabet between the current user logged in and the user profile page they are on
-Conversation.java: added privateConversation attribute in Conversation.java to tell if Conversation is private (not viewable in Conversations tab to everyone).
-User.java: whenever a new User is created, createConversations() is called and a Conversation instance is automatically created with all of the current Users that already exist, so that this User is able to directly message anyone.
-conversations.jsp: when displaying all the conversations, now will only want to display the ones that aren't private.
-Fixed tests b/c Conversation object now has an extra privateConversation attribute.