### PR TITLE
Fixed bug for when users try to create a conversation name as /chat/user1user2 since this URL is used for private conversations between two users.

### DIFF
--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -104,6 +104,9 @@ public class ConversationServlet extends HttpServlet {
       request.setAttribute("error", "Please enter only letters and numbers.");
       request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
       return;
+    } else if (conversationStore.isRestrictedName(conversationTitle)) {
+      request.setAttribute("error", "Please enter a conversation title not consisting of two users as these are reserved for private conversations.");
+      request.getRequestDispatcher("/WEB-INF/view/conversations.jsp").forward(request, response);
     }
 
     if (conversationStore.isTitleTaken(conversationTitle)) {

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -138,7 +138,7 @@ public class User {
     /**
      * When a User is initialized, this method creates a private Conversation with every other User that already exists.
      */
-    private void createConversations() {
+    void createConversations() {
         /* get all Users from UserStore */
         UserStore userStore = UserStore.getInstance();
         List<User> users = userStore.getUsers();
@@ -152,7 +152,7 @@ public class User {
             String secondUser = u.getName();
 
             /* If the order of firstUser and secondUser isn't already in alphabetical order, swap the two users - firstUser and secondUser. */
-            if ((firstUser).compareTo(secondUser) > 0) {
+            if (firstUser.compareTo(secondUser) > 0) {
                 String temp = firstUser;
                 firstUser = secondUser;
                 secondUser = temp;

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -57,31 +57,54 @@ public class ConversationStore {
 
   /** The in-memory list of Conversations. */
   private List<Conversation> conversations;
-	
-	/** The in-memory activity feed conversation. */
-	private Conversation actFeedConversation;
+
+  /** The in-memory activity feed conversation. */
+  private Conversation actFeedConversation;
+
+  /** The in-memory list of restricted conversation names reserved for private conversations. */
+  private List<String> restrictedConversationNames;
 
   /** This class is a singleton, so its constructor is private. Call getInstance() instead. */
   private ConversationStore(PersistentStorageAgent persistentStorageAgent) {
     this.persistentStorageAgent = persistentStorageAgent;
     conversations = new ArrayList<>();
+    restrictedConversationNames = new ArrayList<>();
   }
 
 	/** Access the current set of conversations known to the application. */
   public List<Conversation> getAllConversations() {
     return conversations;
   }
-	
+
 	/** Access the activity feed conversation known to the application. */
   public Conversation getActFeedConversation() {
     return actFeedConversation;
   }
 
+  /** Access the list of restricted conversation names. */
+  public List<String> getRestrictedConversationNames() {
+      return restrictedConversationNames;
+  }
+
+  /** Checks if a name exists in the list of restricted conversation names. */
+  public boolean isRestrictedName(String name) {
+      for (String n: restrictedConversationNames) {
+          if (name.equals(n)) {
+              return true;
+          }
+      }
+      return false;
+  }
 
   /** Add a new conversation to the current set of conversations known to the application. */
   public void addConversation(Conversation conversation) {
     conversations.add(conversation);
     persistentStorageAgent.writeThrough(conversation);
+
+    /* Adds the name to the list of restrictedConversationNames if is a private conversation. */
+    if (conversation.getPrivate()) {
+        restrictedConversationNames.add(conversation.getTitle());
+    }
   }
 
   /** Check whether a Conversation title is already known to the application. */

--- a/src/main/java/codeu/model/store/basic/ConversationStore.java
+++ b/src/main/java/codeu/model/store/basic/ConversationStore.java
@@ -17,6 +17,7 @@ package codeu.model.store.basic;
 import codeu.model.data.Conversation;
 import codeu.model.store.persistence.PersistentStorageAgent;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -61,14 +62,14 @@ public class ConversationStore {
   /** The in-memory activity feed conversation. */
   private Conversation actFeedConversation;
 
-  /** The in-memory list of restricted conversation names reserved for private conversations. */
-  private List<String> restrictedConversationNames;
+  /** The in-memory set of restricted conversation names reserved for private conversations. */
+  private final HashSet<String> restrictedConversationNames;
 
   /** This class is a singleton, so its constructor is private. Call getInstance() instead. */
   private ConversationStore(PersistentStorageAgent persistentStorageAgent) {
     this.persistentStorageAgent = persistentStorageAgent;
     conversations = new ArrayList<>();
-    restrictedConversationNames = new ArrayList<>();
+    restrictedConversationNames = new HashSet<>();
   }
 
 	/** Access the current set of conversations known to the application. */
@@ -81,19 +82,14 @@ public class ConversationStore {
     return actFeedConversation;
   }
 
-  /** Access the list of restricted conversation names. */
-  public List<String> getRestrictedConversationNames() {
+  /** Access the set of restricted conversation names. */
+  public HashSet<String> getRestrictedConversationNames() {
       return restrictedConversationNames;
   }
 
-  /** Checks if a name exists in the list of restricted conversation names. */
+  /** Checks if a name exists in the set of restricted conversation names. */
   public boolean isRestrictedName(String name) {
-      for (String n: restrictedConversationNames) {
-          if (name.equals(n)) {
-              return true;
-          }
-      }
-      return false;
+      return restrictedConversationNames.contains(name);
   }
 
   /** Add a new conversation to the current set of conversations known to the application. */

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -157,6 +157,40 @@ public class PersistentDataStore {
   }
 
   /**
+   * Loads list of restricted conversation names from the Datastore service and returns them in a List, sorted in
+   * ascending order by creation time.
+   *
+   * @throws PersistentDataStoreException if an error was detected during the load from the
+   *     Datastore service
+   */
+  public List<String> loadRestrictedConversationNames() throws PersistentDataStoreException {
+
+    List<String> restrictedConversationNames = new ArrayList<>();
+
+    // Retrieve all conversations from the datastore.
+    Query query = new Query("chat-conversations").addSort("creation_time", SortDirection.ASCENDING);
+    PreparedQuery results = datastore.prepare(query);
+
+    for (Entity entity : results.asIterable()) {
+      try {
+        String title = (String) entity.getProperty("title");
+        boolean privateConversation = Boolean.parseBoolean((String) entity.getProperty("private_conversation"));
+        if (privateConversation) {
+          restrictedConversationNames.add(title);
+        }
+      } catch (Exception e) {
+        // In a production environment, errors should be very rare. Errors which may
+        // occur include network errors, Datastore service errors, authorization errors,
+        // database entity definition mismatches, or service mismatches.
+        throw new PersistentDataStoreException(e);
+      }
+    }
+
+    return restrictedConversationNames;
+  }
+
+
+  /**
    * Loads all Message objects from the Datastore service and returns them in a List, sorted in
    * ascending order by creation time.
    *

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -79,6 +79,16 @@ public class PersistentStorageAgent {
     return persistentDataStore.loadConversations();
   }
 
+  /**
+   * Retrieve list of restricted conversation names from the Datastore service. The returned list may be empty.
+   *
+   * @throws PersistentDataStoreException if an error was detected during the load from the
+   *     Datastore service
+   */
+  public List<String> loadRestrictedConversationNames() throws PersistentDataStoreException {
+    return persistentDataStore.loadRestrictedConversationNames();
+  }
+
 	/**
 	 * Retrieve the Activity Feed's conversation object from the Datastore service.
 	 *

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -34,24 +34,21 @@ UserStore userStore = UserStore.getInstance();
       <% } else {
         if (currentUser != null && currentUser.equals(profileUser)) { %>
             <h1 style="color:dodgerblue">Welcome to your page!</h1>
-        <% } else { %>
+      <% } else if (currentUser != null) { %>
             <h1 style="color:dodgerblue">Welcome to <%= profileUser %>'s Page!</h1>
 
             <%
             String conversationName = "../chat/";
-            String firstUser;
-            String secondUser;
-            /** Gets the conversation link by the names of the two users in alphabetical order */
-            if (currentUser.compareTo(profileUser) < 0) {
-                firstUser = currentUser;
-                secondUser = profileUser;
-            } else {
-                firstUser = profileUser;
-                secondUser = currentUser;
+            String firstUser = currentUser;
+            String secondUser = profileUser;
+
+            if (firstUser.compareTo(secondUser) > 0) {
+                String temp = firstUser;
+                firstUser = secondUser;
+                secondUser = temp;
             }
             conversationName = conversationName + firstUser + secondUser;
             %>
-
             <a href="/chat/<%= conversationName %>"> View Conversation with <%= profileUser %> </a>
 
         <% } %>

--- a/src/test/java/codeu/model/data/ConversationTest.java
+++ b/src/test/java/codeu/model/data/ConversationTest.java
@@ -27,7 +27,7 @@ public class ConversationTest {
     UUID owner = UUID.randomUUID();
     String title = "Test_Title";
     Instant creation = Instant.now();
-    Boolean privateConversation = false;
+    boolean privateConversation = false;
 
     Conversation conversation = new Conversation(id, owner, title, creation, privateConversation);
 

--- a/src/test/java/codeu/model/data/UserTest.java
+++ b/src/test/java/codeu/model/data/UserTest.java
@@ -23,21 +23,21 @@ import org.junit.Test;
 
 public class UserTest {
 
-    @Test
-    public void testCreate() {
-        UUID id = UUID.randomUUID();
-        String name = "test_username";
-        String passwordHash = "$2a$10$bBiLUAVmUFK6Iwg5rmpBUOIBW6rIMhU1eKfi3KR60V9UXaYTwPfHy";
-        Instant creation = Instant.now();
-        Boolean admin = false;
+  @Test
+  public void testCreate() {
+    UUID id = UUID.randomUUID();
+    String name = "test_username";
+    String passwordHash = "$2a$10$bBiLUAVmUFK6Iwg5rmpBUOIBW6rIMhU1eKfi3KR60V9UXaYTwPfHy";
+    Instant creation = Instant.now();
+    Boolean admin = false;
 
-        User user = new User(id, name, passwordHash, creation, admin);
+    User user = new User(id, name, passwordHash, creation, admin);
 
-        Assert.assertEquals(id, user.getId());
-        Assert.assertEquals(name, user.getName());
-        Assert.assertEquals(passwordHash, user.getPasswordHash());
-        Assert.assertEquals(creation, user.getCreationTime());
-        Assert.assertEquals(name + " hasn't written a bio yet.", user.getBio());
-        Assert.assertEquals(false, user.isAdmin());
-    }
+    Assert.assertEquals(id, user.getId());
+    Assert.assertEquals(name, user.getName());
+    Assert.assertEquals(passwordHash, user.getPasswordHash());
+    Assert.assertEquals(creation, user.getCreationTime());
+    Assert.assertEquals(name + " hasn't written a bio yet.", user.getBio());
+    Assert.assertEquals(false, user.isAdmin());
+  }
 }

--- a/src/test/java/codeu/model/data/UserTest.java
+++ b/src/test/java/codeu/model/data/UserTest.java
@@ -14,28 +14,30 @@
 
 package codeu.model.data;
 
+
 import java.time.Instant;
 import java.util.UUID;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 public class UserTest {
 
-  @Test
-  public void testCreate() {
-    UUID id = UUID.randomUUID();
-    String name = "test_username";
-    String passwordHash = "$2a$10$bBiLUAVmUFK6Iwg5rmpBUOIBW6rIMhU1eKfi3KR60V9UXaYTwPfHy";
-    Instant creation = Instant.now();
-    Boolean admin = false;
+    @Test
+    public void testCreate() {
+        UUID id = UUID.randomUUID();
+        String name = "test_username";
+        String passwordHash = "$2a$10$bBiLUAVmUFK6Iwg5rmpBUOIBW6rIMhU1eKfi3KR60V9UXaYTwPfHy";
+        Instant creation = Instant.now();
+        Boolean admin = false;
 
-    User user = new User(id, name, passwordHash, creation, admin);
+        User user = new User(id, name, passwordHash, creation, admin);
 
-    Assert.assertEquals(id, user.getId());
-    Assert.assertEquals(name, user.getName());
-    Assert.assertEquals(passwordHash, user.getPasswordHash());
-    Assert.assertEquals(creation, user.getCreationTime());
-    Assert.assertEquals(name + " hasn't written a bio yet.", user.getBio());
-    Assert.assertEquals(false, user.isAdmin());
-  }
+        Assert.assertEquals(id, user.getId());
+        Assert.assertEquals(name, user.getName());
+        Assert.assertEquals(passwordHash, user.getPasswordHash());
+        Assert.assertEquals(creation, user.getCreationTime());
+        Assert.assertEquals(name + " hasn't written a bio yet.", user.getBio());
+        Assert.assertEquals(false, user.isAdmin());
+    }
 }

--- a/src/test/java/codeu/model/data/UserTest.java
+++ b/src/test/java/codeu/model/data/UserTest.java
@@ -14,7 +14,6 @@
 
 package codeu.model.data;
 
-
 import java.time.Instant;
 import java.util.UUID;
 

--- a/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ConversationStoreTest.java
@@ -101,5 +101,6 @@ public class ConversationStoreTest {
     Assert.assertEquals(expectedConversation.getTitle(), actualConversation.getTitle());
     Assert.assertEquals(
         expectedConversation.getCreationTime(), actualConversation.getCreationTime());
+    Assert.assertEquals(expectedConversation.getPrivate(), actualConversation.getPrivate());
   }
 }

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -39,6 +39,12 @@ public class PersistentStorageAgentTest {
   }
 
   @Test
+  public void testLoadRestrictedConversationNames() throws PersistentDataStoreException {
+    persistentStorageAgent.loadRestrictedConversationNames();
+    Mockito.verify(mockPersistentDataStore).loadRestrictedConversationNames();
+  }
+
+  @Test
   public void testLoadMessages() throws PersistentDataStoreException {
     persistentStorageAgent.loadMessages();
     Mockito.verify(mockPersistentDataStore).loadMessages();


### PR DESCRIPTION
Fixed bug for when users would try to create their own conversation name as /user1user2 since that already exists between two users as their private conversation /chat/user1user2.

- ConversationServlet.java: only allows conversation names that do not include the names of 2 users since the format /chat/user1user2 is restricted for private messages between users.
- User.java: made createConversations() package-private (by default with no modifier) instead of private.
- ConversationStore.java: added List<String> to keep track of the restricted conversation names.
- PersistentStorageAgent.java & PersistentDataStore.java: writing to DataStore.