### PR TITLE
Allows users to send and accept/decline pal requests

### DIFF
--- a/src/main/java/codeu/controller/ProfileServlet.java
+++ b/src/main/java/codeu/controller/ProfileServlet.java
@@ -107,93 +107,143 @@ public class ProfileServlet extends HttpServlet {
     }
 
     /**
-     * This function fires when a user wants to edit his/her own profile page. It checks if the user exists from the username of the URL requested.
-     * It sets the bio parameter to be the user's bio attribute and then updates the user in order to write the data to DataStore.
-     * It then redirects the user back to their profile page.
+     * This function fires when a user edits the bio on his/her own profile page, accept or decline a pal request, or sends
+     * another user a pal request. It then redirects the user back to the profile page they are viewing.
      */
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        if (request.getParameter("bio") != null) {
+            updateBio(request);
+
+        } else if (request.getParameter("accept") != null) {
+            acceptPal(request);
+
+        } else if (request.getParameter("decline") != null) {
+            declinePal(request);
+
+        } else if (request.getParameter("requestPal") != null) {
+            sendPalRequest(request);
+        }
+
+        // gets the username from the request URL
         String requestUrl = request.getRequestURI();
         String profileUsername = requestUrl.substring("/users/".length());
 
-        // 3 forms: deal with updating bio, accept/decline pal request, or sending another user a pal request
-        if (request.getParameter("bio") != null) {
-            // gets user
-            User user = userStore.getUser(profileUsername);
-
-            // gets bio from request
-            String bio = request.getParameter("bio");
-
-            // cleans bio String by removing any HTML tags
-            String cleanedBio = Jsoup.clean(bio, Whitelist.none());
-
-            // sets bio as instance variable for user
-            user.setBio(cleanedBio);
-
-            // updates UserStore to store the bio for next time program opens
-            userStore.updateUser(user);
-
-        } else if (request.getParameter("accept") != null || request.getParameter("decline") != null) {
-            // gets the choice of Accept/Decline that user chose
-            String choiceAccept = request.getParameter("accept");
-            String choiceDecline = request.getParameter("decline");
-
-            // sets the requestee to be the name of the profile page
-            String requestee = profileUsername;
-            User requesteeUser = userStore.getUser(requestee);
-
-            // sets the requester to be the name of the user who sent the pal request
-            String requester = "";
-            User requesterUser = null;
-
-            if (choiceAccept != null) {
-                // sets the requester to be the name of the user who sent the pal request
-                requester = request.getParameter("accept");
-                requesterUser = userStore.getUser(requester);
-
-                // adds requester to list of this user/requestee's pals
-                requesteeUser.addPal(requester);
-
-                // adds this user/requestee to the requester's list of pals
-                requesterUser.addPal(requestee);
-
-            } else if (choiceDecline != null) {
-                // sets the requester to be the name of the user who sent the pal request
-                requester = request.getParameter("decline");
-            }
-
-            // removes requester from this user/requestee's incomingRequests
-            requesteeUser.deleteIncomingRequest(requester);
-
-            // removes this user/requestee from requester's outgoingRequests
-            requesterUser.deleteOutgoingRequest(requestee);
-
-            // updates both users in UserStore
-            userStore.updateUser(requesterUser);
-            userStore.updateUser(requesteeUser);
-
-        } else if (request.getParameter("requestPal") != null) {
-
-            // sets the requester to be the name of the user who sent the pal request
-            String requester = request.getParameter("requestPal");
-            User requesterUser = userStore.getUser(requester);
-
-            // sets the requestee to be the  name of the profile page
-            String requestee = profileUsername;
-            User requesteeUser = userStore.getUser(requestee);
-
-            // for requester, adds name of requestee to the list of their outgoingRequests
-            requesterUser.addOutgoingRequest(requestee);
-
-            // for requestee, adds name of requester to the list of their incomingRequests
-            requesteeUser.addIncomingRequest(requester);
-
-            // updates both users in UserStore
-            userStore.updateUser(requesterUser);
-            userStore.updateUser(requesteeUser);
-        }
-
         // redirects user back to the profile page they are viewing as a GET request
         response.sendRedirect("/users/" + profileUsername);
+    }
+
+    /**
+     *  This helper function cleans the user input and then updates the User's bio attribute.
+     */
+    void updateBio(HttpServletRequest request) {
+        // gets the username from the request URL
+        String requestUrl = request.getRequestURI();
+        String profileUsername = requestUrl.substring("/users/".length());
+
+        // gets user
+        User user = userStore.getUser(profileUsername);
+
+        // gets bio from request
+        String bio = request.getParameter("bio");
+
+        // cleans bio String by removing any HTML tags
+        String cleanedBio = Jsoup.clean(bio, Whitelist.none());
+
+        // sets bio as instance variable for user
+        user.setBio(cleanedBio);
+
+        // updates UserStore to store the bio for next time program opens
+        userStore.updateUser(user);
+    }
+
+    /**
+     *  This helper function adds the two pals to each other's list of pals after one accepts the pal request, removes
+     *  the incoming and outgoing requests and updates both users.
+     */
+    void acceptPal(HttpServletRequest request) {
+        // gets the username from the request URL
+        String requestUrl = request.getRequestURI();
+        String profileUsername = requestUrl.substring("/users/".length());
+
+        // sets the requestee to be the name of the profile page
+        String requestee = profileUsername;
+        User requesteeUser = userStore.getUser(requestee);
+
+        // sets the requester to be the name of the user who sent the pal request
+        String requester = request.getParameter("accept");
+        User requesterUser = userStore.getUser(requester);
+
+        // adds requester to list of this user/requestee's pals
+        requesteeUser.addPal(requester);
+
+        // adds this user/requestee to the requester's list of pals
+        requesterUser.addPal(requestee);
+
+        // removes requester from this user/requestee's incomingRequests
+        requesteeUser.deleteIncomingRequest(requester);
+
+        // removes this user/requestee from requester's outgoingRequests
+        requesterUser.deleteOutgoingRequest(requestee);
+
+        // updates both users in UserStore
+        userStore.updateUser(requesterUser);
+        userStore.updateUser(requesteeUser);
+    }
+
+    /**
+     *  This helper function simply removes the incoming and outgoing requests after one user declines a pal request and
+     *  updates both users.
+     */
+    void declinePal(HttpServletRequest request) {
+        // gets the username from the request URL
+        String requestUrl = request.getRequestURI();
+        String profileUsername = requestUrl.substring("/users/".length());
+
+        // sets the requestee to be the name of the profile page
+        String requestee = profileUsername;
+        User requesteeUser = userStore.getUser(requestee);
+
+        // sets the requester to be the name of the user who sent the pal request
+        String requester = request.getParameter("decline");
+        User requesterUser = userStore.getUser(requester);
+
+        // removes requester from this user/requestee's incomingRequests
+        requesteeUser.deleteIncomingRequest(requester);
+
+        // removes this user/requestee from requester's outgoingRequests
+        requesterUser.deleteOutgoingRequest(requestee);
+
+        // updates both users in UserStore
+        userStore.updateUser(requesterUser);
+        userStore.updateUser(requesteeUser);
+    }
+
+    /**
+     *  This helper function simply adds the requestee to the requester's list of outgoing pal requests and
+     *  adds the requester to the requestee's list of incoming pal requests and then updates both users.
+     */
+    void sendPalRequest(HttpServletRequest request) {
+        // gets the username from the request URL
+        String requestUrl = request.getRequestURI();
+        String profileUsername = requestUrl.substring("/users/".length());
+
+        // sets the requester to be the name of the user who sent the pal request
+        String requester = request.getParameter("requestPal");
+        User requesterUser = userStore.getUser(requester);
+
+        // sets the requestee to be the name of the profile page they are on
+        String requestee = profileUsername;
+        User requesteeUser = userStore.getUser(requestee);
+
+        // for requester, adds name of requestee to the list of their outgoingRequests
+        requesterUser.addOutgoingRequest(requestee);
+
+        // for requestee, adds name of requester to the list of their incomingRequests
+        requesteeUser.addIncomingRequest(requester);
+
+        // updates both users in UserStore
+        userStore.updateUser(requesterUser);
+        userStore.updateUser(requesteeUser);
     }
 }

--- a/src/main/java/codeu/controller/ProfileServlet.java
+++ b/src/main/java/codeu/controller/ProfileServlet.java
@@ -12,7 +12,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-import com.sun.org.apache.xpath.internal.SourceTree;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 import java.util.UUID;

--- a/src/main/java/codeu/controller/ProfileServlet.java
+++ b/src/main/java/codeu/controller/ProfileServlet.java
@@ -116,22 +116,46 @@ public class ProfileServlet extends HttpServlet {
         String requestUrl = request.getRequestURI();
         String profileUsername = requestUrl.substring("/users/".length());
 
-        // gets user
-        User user = userStore.getUser(profileUsername);
+        // 2 forms: deal with updating bio or sends user pal request
+        if (request.getParameter("bio") != null) {
+            // gets user
+            User user = userStore.getUser(profileUsername);
 
-        // gets bio from request
-        String bio = request.getParameter("bio");
+            // gets bio from request
+            String bio = request.getParameter("bio");
 
-        // cleans bio String by removing any HTML tags
-        String cleanedBio = Jsoup.clean(bio, Whitelist.none());
+            // cleans bio String by removing any HTML tags
+            String cleanedBio = Jsoup.clean(bio, Whitelist.none());
 
-        // sets bio as instance variable for user
-        user.setBio(cleanedBio);
+            // sets bio as instance variable for user
+            user.setBio(cleanedBio);
 
-        // updates UserStore to store the bio for next time program opens
-        userStore.updateUser(user);
+            // updates UserStore to store the bio for next time program opens
+            userStore.updateUser(user);
 
-        // redirects user back to their profile page as a GET request
+        } else if (request.getParameter("requestPal") != null) {
+            System.out.println("sending pal request :D");
+
+            // sets the requester to be the name of the user who sent the pal request
+            String requester = (String) request.getParameter("requestPal");
+            User requesterUser = userStore.getUser(requester);
+
+            // sets the requestee to be the  name of the profile page
+            String requestee = profileUsername;
+            User requesteeUser = userStore.getUser(requestee);
+
+            // for requester, adds name of requestee to the list of their outgoingRequests
+            requesterUser.addOutgoingRequest(requestee);
+
+            // for requestee, adds name of requester to the list of their incomingRequests
+            requesteeUser.addIncomingRequest(requester);
+
+            // updates both users in UserStore
+            userStore.updateUser(requesterUser);
+            userStore.updateUser(requesteeUser);
+        }
+
+        // redirects user back to the profile page they are viewing as a GET request
         response.sendRedirect("/users/" + profileUsername);
     }
 }

--- a/src/main/java/codeu/controller/ProfileServlet.java
+++ b/src/main/java/codeu/controller/ProfileServlet.java
@@ -174,7 +174,6 @@ public class ProfileServlet extends HttpServlet {
             userStore.updateUser(requesteeUser);
 
         } else if (request.getParameter("requestPal") != null) {
-            System.out.println("sending pal request :D");
 
             // sets the requester to be the name of the user who sent the pal request
             String requester = request.getParameter("requestPal");

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -141,9 +141,11 @@ public class User {
         return pals;
     }
 
-    /** Adds a pal to the list of this User's pals. */
+    /** Adds a pal to the list of this User's pals as long as the pal is not this User. */
     public void addPal(String name) {
-        this.pals.add(name);
+        if (!name.equals(this.name)) {
+            this.pals.add(name);
+        }
     }
 
     /** Checks whether a given name is in this User's list of pals. */

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -172,6 +172,11 @@ public class User {
         this.incomingRequests.remove(name);
     }
 
+    /** Checks whether this User has sent another user/name a pal request. */
+    public boolean sentPalRequest(String name) {
+        return this.outgoingRequests.contains(name);
+    }
+
     /**
      * Returns the incoming requests of this User.
      */

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -143,7 +143,9 @@ public class User {
 
     /** Adds a pal to the list of this User's pals as long as the pal is not this User. */
     public void addPal(String name) {
-        if (!name.equals(this.name)) {
+        /* Validate user input & only add the pal if he/she isn't this User and is not already a pal. */
+        UserStore userStore = UserStore.getInstance();
+        if (name.matches("[\\w*\\s*]*") && userStore.isUserRegistered(name) && !name.equals(this.name) && !isPal(name)) {
             this.pals.add(name);
         }
     }

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -56,6 +56,15 @@ UserStore userStore = UserStore.getInstance();
             <%
             } else {
               System.out.println("Not friends yet");
+              %>
+
+              <% /** Gives current user a button to request this user as a pal */ %>
+              <form action="/users/<%= profileUser %>" method="POST">
+                <button type="submit" name="requestPal" value="<%= currentUser %>"> Request Pal </button>
+                <br/>
+              </form>
+
+              <%
             }
             %>
 

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -42,11 +42,10 @@ UserStore userStore = UserStore.getInstance();
             <%
             }
             for (String requester: incomingRequests) {
-                 /** Gives current user a button to request this user as a pal */ %>
+                 /** Lists the incoming requests for current user to accept or decline */ %>
                  <p> <%= requester %> has sent you a pal request: </p>
                  <form action="/users/<%= profileUser %>" method="POST">
                    <button type="submit" name="accept" value="<%= requester %>"> Accept </button>
-                   <br/>
                    <button type="submit" name="decline" value="<%= requester %>"> Decline </button>
                    <br/>
                  </form>
@@ -76,6 +75,15 @@ UserStore userStore = UserStore.getInstance();
                 if (currUser.sentPalRequest(profileUser)) {
                     /** States that the current user has already sent this profile user a pal request */ %>
                     <p> Pal Request sent! </p>
+                    <%
+                } else if (profUser.sentPalRequest(currentUser)) {
+                    /** Gives current user the option to accept or decline request on this user profile page */ %>
+                    <p> <%= profileUser %> has sent you a pal request: </p>
+                      <form action="/users/<%= profileUser %>" method="POST">
+                        <button type="submit" name="accept" value="<%= profileUser %>"> Accept </button>
+                        <button type="submit" name="decline" value="<%= profileUser %>"> Decline </button>
+                        <br/>
+                      </form>
                     <%
                 } else {
                     /** Gives current user a button to request this user as a pal */ %>

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -4,6 +4,7 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Iterator" %>
 <%@ page import="java.time.Instant" %>
+<%@ page import="java.util.ArrayList" %>
 <%
 /** Gets the UserStore instance to access all users. */
 UserStore userStore = UserStore.getInstance();
@@ -34,7 +35,24 @@ UserStore userStore = UserStore.getInstance();
 
       <% } else {
         if (currentUser != null && currentUser.equals(profileUser)) { %>
+            <% /** Iterates through any incoming pal requests for user to accept/decline */
+            List<String> incomingRequests = currUser.getIncomingRequests();
+            if (incomingRequests.size() > 0) { %>
+                <p> You have some notifications! </p>
+            <%
+            }
+            for (String requester: incomingRequests) {
+                 /** Gives current user a button to request this user as a pal */ %>
+                 <p> <%= requester %> has sent you a pal request: </p>
+                 <form action="/users/<%= profileUser %>" method="POST">
+                   <button type="submit" name="accept" value="<%= requester %>"> Accept </button>
+                   <br/>
+                   <button type="submit" name="decline" value="<%= requester %>"> Decline </button>
+                   <br/>
+                 </form>
+            <% } %>
             <h1 style="color:dodgerblue">Welcome to your page!</h1>
+
       <% } else if (currentUser != null) { %>
             <h1 style="color:dodgerblue">Welcome to <%= profileUser %>'s Page!</h1>
 

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -69,7 +69,7 @@ UserStore userStore = UserStore.getInstance();
               }
               conversationName = conversationName + firstUser + "-" +secondUser;
               %>
-              <a href="/chat/<%= conversationName %>"> View Conversation with <%= profileUser %> </a>
+              <a href="/chat/<%= conversationName %>"> Send a direct message to <%= profileUser %> </a>
             <%
             } else {
                 if (currUser.sentPalRequest(profileUser)) {

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -4,7 +4,6 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Iterator" %>
 <%@ page import="java.time.Instant" %>
-<%@ page import="java.util.ArrayList" %>
 <%
 /** Gets the UserStore instance to access all users. */
 UserStore userStore = UserStore.getInstance();

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -73,7 +73,6 @@ UserStore userStore = UserStore.getInstance();
               <a href="/chat/<%= conversationName %>"> View Conversation with <%= profileUser %> </a>
             <%
             } else {
-              System.out.println("Not friends yet");
               %>
 
               <% /** Gives current user a button to request this user as a pal */ %>

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -73,15 +73,18 @@ UserStore userStore = UserStore.getInstance();
               <a href="/chat/<%= conversationName %>"> View Conversation with <%= profileUser %> </a>
             <%
             } else {
-              %>
-
-              <% /** Gives current user a button to request this user as a pal */ %>
-              <form action="/users/<%= profileUser %>" method="POST">
-                <button type="submit" name="requestPal" value="<%= currentUser %>"> Request Pal </button>
-                <br/>
-              </form>
-
-              <%
+                if (currUser.sentPalRequest(profileUser)) {
+                    /** States that the current user has already sent this profile user a pal request */ %>
+                    <p> Pal Request sent! </p>
+                    <%
+                } else {
+                    /** Gives current user a button to request this user as a pal */ %>
+                       <form action="/users/<%= profileUser %>" method="POST">
+                         <button type="submit" name="requestPal" value="<%= currentUser %>"> Request Pal </button>
+                         <br/>
+                       </form>
+                    <%
+                }
             }
             %>
 


### PR DESCRIPTION
ProfileServlet.java:
- 3 different forms: 
1) getParameter("bio"): sets the user bio (already done)
2) getParameter("accept")/getParameter("decline"): deals with accept/decline choice that user pressed [If accept, then add corresponding users to each other's list of pals. If either accept/decline, then remove requester from requestee's list of incoming requests and remove requestee from requester's list of outgoing requests.]
3) getParameter("palRequest"): works with a sent pal request. Adds requestee to list of requester's outgoing requests and adds requester to requestee's list of incoming requests.
After any of these forms, redirect user back to the page they are currently viewing.

User.java:
- modified addPal to only allow a user to add another name if they are not the same user [cannot be pals with oneself]
- added sentPalRequest(String name) to check if this user has sent some username a pal request.

profile.jsp:
1) if current user is viewing his/her own page, then can edit bio (already done) AND can view list of incoming requests to accept/decline any pal requests
2) if the current user and the person whose page they are viewing are pals, allow them to view to send a direct private message to this person 
Else if the current user and the person whose page they are viewing are not yet pals:
- if the current user has sent the person whose page they are viewing a pal request, it will state "Pal Request sent!"
- if the person whose page the current user is viewing has sent the current user a pal request, it will have the accept/decline buttons so they can respond
- else neither of these users have sent each other a pal request, so have a button to allow them to request each other as pals

** I wanted to keep this pull request focused on functionality and fairly simple/not too big, so I will include the tests for these different situations/conditions in the next pull request.