### PR TITLE
Toggle sort feature implemented

### DIFF
--- a/src/main/java/codeu/controller/ActivityFeedServlet.java
+++ b/src/main/java/codeu/controller/ActivityFeedServlet.java
@@ -3,8 +3,11 @@ package codeu.controller;
 import codeu.model.data.Activity;
 import codeu.model.store.basic.ActivityStore;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.Collections;
+import java.util.Comparator;
 
 import java.io.IOException;
 import javax.servlet.ServletException;
@@ -20,7 +23,7 @@ import org.jsoup.safety.Whitelist;
 
 public class ActivityFeedServlet extends HttpServlet {
 
-  /** Store class that gives access to Conversations. */
+  /** Store class that gives access to Activities. */
   private ActivityStore activityStore;
 
   /**
@@ -51,24 +54,61 @@ public class ActivityFeedServlet extends HttpServlet {
     List<Activity> activities = activityStore.getActivities();
 
     request.setAttribute("activities", activities);
+    request.setAttribute("checked", "recent");
 
     request.getRequestDispatcher("/WEB-INF/view/activityfeed.jsp").forward(request, response);
-
 
   }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
 
-    String username = request.getParameter("searchQuery");
+    List<Activity> activities = (List<Activity>) request.getSession().getAttribute("activities");
 
-    String cleanedUsername = Jsoup.clean(username, Whitelist.none());
 
-    List<Activity> activities = activityStore.getUserActivities(cleanedUsername);
+    /*If the user posts a search request that isn't an empty string, reassembles the list of activities */
+    if (request.getParameter("searchQuery") != null && !request.getParameter("searchQuery").equals("")) {
+      String username = request.getParameter("searchQuery");
+
+      String cleanedUsername = Jsoup.clean(username, Whitelist.none());
+
+      activities = activityStore.getUserActivities(cleanedUsername);
+      request.setAttribute("searchQuery", cleanedUsername);
+    }
+
+    /* If one of the sorting radio buttons are been toggled, sorts the list of activities*/
+
+    if (request.getParameter("sortingStyle") != null) {
+
+      if(request.getParameter("sortingStyle").equals("popular")) {
+
+        /*Sorts activities by allTimeCount field*/
+        Collections.sort(activities, new Comparator<Activity>() {
+          public int compare(Activity one, Activity other) {
+            return other.getAllTimeCount() - one.getAllTimeCount();
+          }
+        });
+
+        request.setAttribute("checked", "popular");
+
+      } else if (request.getParameter("sortingStyle").equals("recent")) {
+
+        /*Sorts activities by creationTime field*/
+        Collections.sort(activities, new Comparator<Activity>() {
+          public int compare(Activity one, Activity other) {
+            return other.getCreationTime().compareTo(one.getCreationTime());
+          }
+        });
+
+        request.setAttribute("checked", "recent");
+
+      }
+
+
+    }
 
     request.setAttribute("activities", activities);
 
     request.getRequestDispatcher("/WEB-INF/view/activityfeed.jsp").forward(request, response);
   }
-
 }

--- a/src/main/java/codeu/controller/ActivityFeedServlet.java
+++ b/src/main/java/codeu/controller/ActivityFeedServlet.java
@@ -53,6 +53,13 @@ public class ActivityFeedServlet extends HttpServlet {
 
     List<Activity> activities = activityStore.getActivities();
 
+    /*Sorts activities by creationTime field*/
+    Collections.sort(activities, new Comparator<Activity>() {
+      public int compare(Activity one, Activity other) {
+        return other.getCreationTime().compareTo(one.getCreationTime());
+      }
+    });
+
     request.setAttribute("activities", activities);
     request.setAttribute("checked", "recent");
 
@@ -64,8 +71,8 @@ public class ActivityFeedServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
 
     List<Activity> activities = (List<Activity>) request.getSession().getAttribute("activities");
-
-
+    String toggle = "Undefined";
+    String sortingStyle = request.getParameter("sortingStyle") == null? "Undefined":request.getParameter("sortingStyle");
     /*If the user posts a search request that isn't an empty string, reassembles the list of activities */
     if (request.getParameter("searchQuery") != null && !request.getParameter("searchQuery").equals("")) {
       String username = request.getParameter("searchQuery");
@@ -74,13 +81,24 @@ public class ActivityFeedServlet extends HttpServlet {
 
       activities = activityStore.getUserActivities(cleanedUsername);
       request.setAttribute("searchQuery", cleanedUsername);
+
+      toggle = request.getParameter("checked");
+
+      if (toggle.equals("popular")) {
+        request.setAttribute("checked", "popular");
+      } else if (toggle.equals("recent")) {
+        request.setAttribute("checked", "recent");
+      }
+
     }
 
     /* If one of the sorting radio buttons are been toggled, sorts the list of activities*/
 
-    if (request.getParameter("sortingStyle") != null) {
+    //if (request.getParameter("sortingStyle") != null) {
 
-      if(request.getParameter("sortingStyle").equals("popular")) {
+
+
+      if(sortingStyle.equals("popular") || toggle.equals("popular")) {
 
         /*Sorts activities by allTimeCount field*/
         Collections.sort(activities, new Comparator<Activity>() {
@@ -91,7 +109,7 @@ public class ActivityFeedServlet extends HttpServlet {
 
         request.setAttribute("checked", "popular");
 
-      } else if (request.getParameter("sortingStyle").equals("recent")) {
+      } else if (sortingStyle.equals("recent") || toggle.equals("recent")) {
 
         /*Sorts activities by creationTime field*/
         Collections.sort(activities, new Comparator<Activity>() {
@@ -105,7 +123,7 @@ public class ActivityFeedServlet extends HttpServlet {
       }
 
 
-    }
+    //}
 
     request.setAttribute("activities", activities);
 

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -133,7 +133,7 @@ public class ConversationServlet extends HttpServlet {
 
     conversationStore.addConversation(conversation);
 
-    Activity activity = new Activity(UUID.randomUUID(), 0, Instant.now(), "started a new ", user.getId(), user.getName(), ActivityType.CONVERSATION, conversation.getId(), conversation.getTitle());
+    Activity activity = new Activity(UUID.randomUUID(), 1, Instant.now(), "started a new ", user.getId(), user.getName(), ActivityType.CONVERSATION, conversation.getId(), conversation.getTitle());
     activityStore.addActivity(activity);
 
     response.sendRedirect("/chat/" + conversationTitle);

--- a/src/main/java/codeu/model/data/Activity.java
+++ b/src/main/java/codeu/model/data/Activity.java
@@ -2,13 +2,14 @@ package codeu.model.data;
 
 import java.time.Instant;
 import java.util.UUID;
+import java.io.Serializable;
 
 /** Class representing an activity, which is used to log/track
  * significant/trending data and present this information on the
  * activity feed.
  */
 
-public class Activity {
+public class Activity implements Serializable {
 
   /**
    * Enum used to give a "type" to an activity object,

--- a/src/main/webapp/WEB-INF/view/activityfeed.jsp
+++ b/src/main/webapp/WEB-INF/view/activityfeed.jsp
@@ -86,7 +86,7 @@
 
   <form action="/activityfeed" method= "POST">
 		<input type="text" name="searchQuery">
-
+		<input type="hidden" name="checked" value=<%= checked%> >
 		<button type = "submit">Search User</button>
 	</form>
 

--- a/src/main/webapp/WEB-INF/view/activityfeed.jsp
+++ b/src/main/webapp/WEB-INF/view/activityfeed.jsp
@@ -42,8 +42,8 @@
 
 		<div>
 			<form id="sortingForm" action="/activityfeed" method= "POST">
-					<input type="radio" id="recencySort" name="sortingStyle" onclick="callServlet('POST')" value="recent" <%= checked.equals("recent")? "checked":""%> > Recent
-					<input type="radio" id="popularitySort" name="sortingStyle" onclick="callServlet('POST')" value="popular" <%= checked.equals("popular")? "checked":""%> > Popular
+					<input type="radio" id="recencySort" name="sortingStyle" onclick="callServlet('POST')" value="recent" <%= checked != null && checked.equals("recent")? "checked":""%> > Recent
+					<input type="radio" id="popularitySort" name="sortingStyle" onclick="callServlet('POST')" value="popular" <%= checked != null && checked.equals("popular")? "checked":""%> > Popular
 			</form>
 
 		</div>

--- a/src/main/webapp/WEB-INF/view/activityfeed.jsp
+++ b/src/main/webapp/WEB-INF/view/activityfeed.jsp
@@ -1,11 +1,14 @@
 <%@ page import="java.util.List" %>
+<%@ page import="java.util.ArrayList" %>
 <%@ page import="codeu.model.data.Conversation" %>
 <%@ page import="codeu.model.data.Message" %>
 <%@ page import="codeu.model.data.Activity" %>
 <%@ page import="codeu.model.data.Activity.ActivityType" %>
 <%@ page import="codeu.model.store.basic.UserStore" %>
 <%
-List<Activity> activities = (List<Activity>) request.getAttribute("activities");
+	List<Activity> activities = (List<Activity>) request.getAttribute("activities");
+	request.getSession().setAttribute("activities", activities );
+	String checked = (String) request.getAttribute("checked");
 %>
 
 <!DOCTYPE html>
@@ -15,6 +18,19 @@ List<Activity> activities = (List<Activity>) request.getAttribute("activities");
 	<link rel="stylesheet" href="/css/main.css" type="text/css">
 
 	<%@include file= "chatbox.jsp"%>
+
+	<script type="text/javascript">
+
+		function callServlet(methodType) {
+			document.getElementById("sortingForm").action="/activityfeed";
+			document.getElementById("sortingForm").method = methodType;
+			document.getElementById("sortingForm").submit();
+		}
+
+
+	</script>
+
+
 </head>
 <body onload= "scrollChat()">
 
@@ -24,7 +40,13 @@ List<Activity> activities = (List<Activity>) request.getAttribute("activities");
  		<h1>Activity Feed
 			<a href="" style="float: right">&#8635;</a></h1>
 
-	  <hr/>
+		<div>
+			<form id="sortingForm" action="/activityfeed" method= "POST">
+					<input type="radio" id="recencySort" name="sortingStyle" onclick="callServlet('POST')" value="recent" <%= checked.equals("recent")? "checked":""%> > Recent
+					<input type="radio" id="popularitySort" name="sortingStyle" onclick="callServlet('POST')" value="popular" <%= checked.equals("popular")? "checked":""%> > Popular
+			</form>
+
+		</div>
 
 	<div id="chat">
 		<ul>

--- a/src/test/java/codeu/controller/ActivityFeedServletTest.java
+++ b/src/test/java/codeu/controller/ActivityFeedServletTest.java
@@ -78,6 +78,10 @@ public class ActivityFeedServletTest {
     Mockito.when(mockRequest.getParameter("searchQuery")).thenReturn("test_activity");
     Mockito.when(mockActivityStore.getUserActivities("test_activity")).thenReturn(fakeActivityList);
 
+    Mockito.when(mockRequest.getParameter("checked")).thenReturn("undefined");
+    Mockito.when(mockRequest.getParameter("sortingStyle")).thenReturn("undefined");
+
+
     activityFeedServlet.doPost(mockRequest, mockResponse);
 
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
@@ -93,11 +97,15 @@ public class ActivityFeedServletTest {
 
     Mockito.when(mockRequest.getParameter("searchQuery")).thenReturn("<h1> test_activity <h1>");
     Mockito.when(mockActivityStore.getUserActivities("test_activity")).thenReturn(fakeActivityList);
+    Mockito.when(mockRequest.getParameter("checked")).thenReturn("recent");
+
+    Mockito.when(mockRequest.getParameter("checked")).thenReturn("undefined");
+    Mockito.when(mockRequest.getParameter("sortingStyle")).thenReturn("undefined");
 
     activityFeedServlet.doPost(mockRequest, mockResponse);
 
     Mockito.verify(mockRequestDispatcher).forward(mockRequest, mockResponse);
 
   }
-  
+
 }


### PR DESCRIPTION
![screenshot from 2018-07-12 05-15-08](https://user-images.githubusercontent.com/34404115/42628593-347b363c-8596-11e8-895f-087515d228b0.png)
All together these changes allow the users to toggle between displaying "activities" in order of most recent or most popular. This feature works in conjunction with the "search user" feature (A lot of the logic placed into the servlet and jsp files is there to ensure that neither feature overrides the other).

The Popularity (ie. AllTimeCount) of Activities does not increase at the moment but that will be coming in future updates.

I will also make sure that I include all of my updated tests in a pull request very soon.

*Activity.java
++Updated to make the class "Serializable", so that a List of Activity objects can be passed from the jsp to the servlet as a session variable

*ConversationServlet.java
++Updated so that Activity objects of type Conversation automatically start with an allTimeCount of 1

*ActivityFeedServlet.java
++Updated to re-sort and return the list of Activities when a radio button is toggled
++Updated so that the previously displayed list of Activities is displayed when a user enters an empty string into the "search user" field

*ActivityFeed.jsp
++Updated to include radio buttons that allow the user to toggle between sorting activities by popularity and recency.
++Stores list of activity objects in session to pass to servlet when making a post request 
++Communicates with servlet to ensure that radio buttons remain checked after page reloads 
