### PR TITLE
Added boolean privateMessage attribute so that messages in private conversations are not shown as user's sent messages on profile page

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -203,10 +203,7 @@ public class ChatServlet extends HttpServlet {
     // this removes any HTML from the message content
     String cleanedMessageContent = Jsoup.clean(messageContent, Whitelist.none());
 
-    boolean privateMessage = false;
-    if (conversation.getPrivate()) {
-      privateMessage = true;
-    }
+    boolean privateMessage = conversation.getPrivate();
 
     Message message =
         new Message(

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -203,13 +203,19 @@ public class ChatServlet extends HttpServlet {
     // this removes any HTML from the message content
     String cleanedMessageContent = Jsoup.clean(messageContent, Whitelist.none());
 
+    boolean privateMessage = false;
+    if (conversation.getPrivate()) {
+      privateMessage = true;
+    }
+
     Message message =
         new Message(
             UUID.randomUUID(),
             conversation.getId(),
             user.getId(),
             cleanedMessageContent,
-            Instant.now());
+            Instant.now(),
+            privateMessage);
 
     messageStore.addMessage(message);
 

--- a/src/main/java/codeu/model/data/Message.java
+++ b/src/main/java/codeu/model/data/Message.java
@@ -28,6 +28,7 @@ public class Message {
   private final UUID author;
   private final String content;
   private final Instant creation;
+  private final boolean privateMessage;
 
   /**
    * Constructs a new Message.
@@ -38,12 +39,13 @@ public class Message {
    * @param content the text content of this Message
    * @param creation the creation time of this Message
    */
-  public Message(UUID id, UUID conversation, UUID author, String content, Instant creation) {
+  public Message(UUID id, UUID conversation, UUID author, String content, Instant creation, boolean privateMessage) {
     this.id = id;
     this.conversation = conversation;
     this.author = author;
     this.content = content;
     this.creation = creation;
+    this.privateMessage = privateMessage;
   }
 
   /** Returns the ID of this Message. */
@@ -69,6 +71,11 @@ public class Message {
   /** Returns the creation time of this Message. */
   public Instant getCreationTime() {
     return creation;
+  }
+
+  /** Returns whether or not this message is part of a private conversation. */
+  public boolean isPrivate() {
+    return privateMessage;
   }
 
 }

--- a/src/main/java/codeu/model/data/Utils.java
+++ b/src/main/java/codeu/model/data/Utils.java
@@ -11,13 +11,21 @@ public class Utils {
         LocalDateTime localDate = LocalDateTime.ofInstant(creation, ZoneId.systemDefault());
         int hour = localDate.getHour();
         String timeAMPM = "";
-        if (hour > 12) {
+        if (hour == 0) {
+            hour = 12;
+            timeAMPM = "AM";
+        } else if (hour >= 12) {
             hour = hour % 12;
             timeAMPM = "PM";
         } else {
             timeAMPM = "AM";
         }
-        String date = localDate.getMonth().toString() + " " + localDate.getDayOfMonth() + ", " + localDate.getYear() + " - " + hour + ":" + localDate.getMinute() + " " + timeAMPM;
+        int minute = localDate.getMinute();
+        String strMinute = "" + minute;
+        if (minute < 10) {
+            strMinute = "0" + minute;
+        }
+        String date = localDate.getMonth().toString() + " " + localDate.getDayOfMonth() + ", " + localDate.getYear() + " - " + hour + ":" + strMinute + " " + timeAMPM;
         return date;
     }
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -187,7 +187,8 @@ public class PersistentDataStore {
         UUID authorUuid = UUID.fromString((String) entity.getProperty("author_uuid"));
         Instant creationTime = Instant.parse((String) entity.getProperty("creation_time"));
         String content = (String) entity.getProperty("content");
-        Message message = new Message(uuid, conversationUuid, authorUuid, content, creationTime);
+        boolean privateMessage = Boolean.parseBoolean((String) entity.getProperty("private_message"));
+        Message message = new Message(uuid, conversationUuid, authorUuid, content, creationTime, privateMessage);
         messages.add(message);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
@@ -266,6 +267,7 @@ public class PersistentDataStore {
     messageEntity.setProperty("author_uuid", message.getAuthorId().toString());
     messageEntity.setProperty("content", message.getContent());
     messageEntity.setProperty("creation_time", message.getCreationTime().toString());
+    messageEntity.setProperty("private_message", Boolean.toString(message.isPrivate()));
     datastore.put(messageEntity);
   }
 

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -136,10 +136,14 @@ UserStore userStore = UserStore.getInstance();
         <% } %>
         <h2 style="color:skyblue"> <%= profileUser %>'s Sent Messages </h2>
         <% List<Message> userMessages = (List) request.getAttribute("messages");
-            for (Message m: userMessages) { %>
+            for (Message m: userMessages) {
+                if (!m.isPrivate()) {
+            %>
                 <a> <strong> <%= Utils.getTime(m.getCreationTime()) %> </strong> : <%= m.getContent() %> </a>
                 <br/>
-            <% } %>
+            <%
+            }
+             } %>
 
         </br>
         <h2 style="color:skyblue"> <%= profileUser %>'s Pals </h2>

--- a/src/test/java/codeu/controller/AdminServletTest.java
+++ b/src/test/java/codeu/controller/AdminServletTest.java
@@ -127,7 +127,8 @@ public class AdminServletTest {
                     fakeConversationId,
                     UUID.randomUUID(),
                     "test message",
-                    Instant.now()));
+                    Instant.now(),
+                    false));
 
     fakeConversationList.add(
             new Conversation(

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -87,7 +87,8 @@ public class ChatServletTest {
             fakeConversationId,
             UUID.randomUUID(),
             "test message",
-            Instant.now()));
+            Instant.now(),
+            false));
     Mockito.when(mockMessageStore.getMessagesInConversation(fakeConversationId))
         .thenReturn(fakeMessageList);
 

--- a/src/test/java/codeu/model/data/MessageTest.java
+++ b/src/test/java/codeu/model/data/MessageTest.java
@@ -28,13 +28,15 @@ public class MessageTest {
     UUID author = UUID.randomUUID();
     String content = "test content";
     Instant creation = Instant.now();
+    boolean privateMessage = false;
 
-    Message message = new Message(id, conversation, author, content, creation);
+    Message message = new Message(id, conversation, author, content, creation, privateMessage);
 
     Assert.assertEquals(id, message.getId());
     Assert.assertEquals(conversation, message.getConversationId());
     Assert.assertEquals(author, message.getAuthorId());
     Assert.assertEquals(content, message.getContent());
     Assert.assertEquals(creation, message.getCreationTime());
+    Assert.assertEquals(privateMessage, message.isPrivate());
   }
 }

--- a/src/test/java/codeu/model/store/basic/MessageStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/MessageStoreTest.java
@@ -27,21 +27,24 @@ public class MessageStoreTest {
                     CONVERSATION_ID_ONE,
                     USER_ONE,
                     "message one",
-                    Instant.ofEpochMilli(1000));
+                    Instant.ofEpochMilli(1000),
+                    false);
     private final Message MESSAGE_TWO =
             new Message(
                     UUID.randomUUID(),
                     CONVERSATION_ID_ONE,
                     UUID.randomUUID(),
                     "message two",
-                    Instant.ofEpochMilli(2000));
+                    Instant.ofEpochMilli(2000),
+                    false);
     private final Message MESSAGE_THREE =
             new Message(
                     UUID.randomUUID(),
                     UUID.randomUUID(),
                     USER_ONE,
                     "message three",
-                    Instant.ofEpochMilli(3000));
+                    Instant.ofEpochMilli(3000),
+                    false);
 
     @Before
     public void setup() {
@@ -73,7 +76,8 @@ public class MessageStoreTest {
                         inputConversationId,
                         UUID.randomUUID(),
                         "test message",
-                        Instant.now());
+                        Instant.now(),
+                        false);
 
         messageStore.addMessage(inputMessage);
         Message resultMessage = messageStore.getMessagesInConversation(inputConversationId).get(0);

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -155,16 +155,18 @@ public class PersistentDataStoreTest {
     UUID authorOne = UUID.fromString("10000002-2222-3333-4444-555555555555");
     String contentOne = "test content one";
     Instant creationOne = Instant.ofEpochMilli(1000);
+    boolean privateMessageOne = false;
     Message inputMessageOne =
-        new Message(idOne, conversationOne, authorOne, contentOne, creationOne);
+        new Message(idOne, conversationOne, authorOne, contentOne, creationOne, privateMessageOne);
 
     UUID idTwo = UUID.fromString("10000003-2222-3333-4444-555555555555");
     UUID conversationTwo = UUID.fromString("10000004-2222-3333-4444-555555555555");
     UUID authorTwo = UUID.fromString("10000005-2222-3333-4444-555555555555");
     String contentTwo = "test content one";
     Instant creationTwo = Instant.ofEpochMilli(2000);
+    boolean privateMessageTwo = true;
     Message inputMessageTwo =
-        new Message(idTwo, conversationTwo, authorTwo, contentTwo, creationTwo);
+        new Message(idTwo, conversationTwo, authorTwo, contentTwo, creationTwo, privateMessageTwo);
 
         // save
     persistentDataStore.writeThrough(inputMessageOne);
@@ -180,6 +182,7 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(authorOne, resultMessageOne.getAuthorId());
     Assert.assertEquals(contentOne, resultMessageOne.getContent());
     Assert.assertEquals(creationOne, resultMessageOne.getCreationTime());
+    Assert.assertEquals(privateMessageOne, resultMessageOne.isPrivate());
 
     Message resultMessageTwo = resultMessages.get(1);
     Assert.assertEquals(idTwo, resultMessageTwo.getId());
@@ -187,6 +190,7 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(authorTwo, resultMessageTwo.getAuthorId());
     Assert.assertEquals(contentTwo, resultMessageTwo.getContent());
     Assert.assertEquals(creationTwo, resultMessageTwo.getCreationTime());
+    Assert.assertEquals(privateMessageTwo, resultMessageTwo.isPrivate());
   }
 
   @Test

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -77,7 +77,7 @@ public class PersistentStorageAgentTest {
   public void testWriteThroughMessage() {
     Message message =
         new Message(
-            UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "test content", Instant.now());
+            UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), "test content", Instant.now(), false);
     persistentStorageAgent.writeThrough(message);
     Mockito.verify(mockPersistentDataStore).writeThrough(message);
   }


### PR DESCRIPTION
ChatServlet.java:
- when creating a message, sets privateMessage boolean to be true if the conversation is private

Message.java, PersistentDataStore.java:
- added privateMessage boolean attribute
- added isPrivate() method
- added to writeThrough() method in PersistentDataStore.java

Utils.java
- fixed bug in getTime() to display 12 AM instead of 0 AM
- fixed bug so that minutes with 1 digit is appeared as 06, instead of 6

profile.jsp:
- only displays user's sent messages on their profile page if they are not private messages

PersistentDataStoreTest.java, MessageTest.java, MessageStoreTest.java, AdminServletTest.java, ChatServletTest.java, PersistentStorageAgentTest.java:
- fixed test cases with new attribute in Message