### PR TITLE
Implementing a fluid popularity system for use with the activity feed

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -85,12 +85,12 @@ private ActivityStore activityStore;
   }
 
   /**
- * Sets the ConversationStore used by this servlet. This function provides a common setup method
- * for use by the test framework or the servlet's init() function.
- */
-void setActivityStore(ActivityStore activityStore) {
-  this.activityStore = activityStore;
-}
+  * Sets the ConversationStore used by this servlet. This function provides a common setup method
+  * for use by the test framework or the servlet's init() function.
+  */
+  void setActivityStore(ActivityStore activityStore) {
+    this.activityStore = activityStore;
+  }
 
   /**
    * This function fires when a user navigates to the chat page. It gets the conversation title from

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -17,9 +17,11 @@ package codeu.controller;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
+import codeu.model.data.Activity;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.ActivityStore;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
@@ -43,6 +45,9 @@ public class ChatServlet extends HttpServlet {
   /** Store class that gives access to Users. */
   private UserStore userStore;
 
+  /** Store class that gives access to Activity. */
+private ActivityStore activityStore;
+
   /** Set up state for handling chat requests. */
   @Override
   public void init() throws ServletException {
@@ -50,6 +55,7 @@ public class ChatServlet extends HttpServlet {
     setConversationStore(ConversationStore.getInstance());
     setMessageStore(MessageStore.getInstance());
     setUserStore(UserStore.getInstance());
+    setActivityStore(ActivityStore.getInstance());
   }
 
   /**
@@ -75,6 +81,14 @@ public class ChatServlet extends HttpServlet {
   void setUserStore(UserStore userStore) {
     this.userStore = userStore;
   }
+
+  /**
+ * Sets the ConversationStore used by this servlet. This function provides a common setup method
+ * for use by the test framework or the servlet's init() function.
+ */
+void setActivityStore(ActivityStore activityStore) {
+  this.activityStore = activityStore;
+}
 
   /**
    * This function fires when a user navigates to the chat page. It gets the conversation title from
@@ -152,6 +166,10 @@ public class ChatServlet extends HttpServlet {
             Instant.now());
 
     messageStore.addMessage(message);
+
+    Activity conversationActivity = activityStore.getActivityWithConversationName(conversationTitle);
+    conversationActivity.increaseAllTimeCount();
+    activityStore.updateActivity(conversationActivity);
 
     // redirect to a GET request
     response.sendRedirect("/chat/" + conversationTitle);

--- a/src/main/java/codeu/model/store/basic/ActivityStore.java
+++ b/src/main/java/codeu/model/store/basic/ActivityStore.java
@@ -88,6 +88,22 @@ public class ActivityStore {
     return activities;
   }
 
+  /** Find and return activity associated with a conversationName */
+  public Activity getActivityWithConversationName(String conversationName) {
+
+    for (Activity activity: this.activities) {
+      if (activity.getActivityType() != ActivityType.REGISTRATION && activity.getConversationName().equals(conversationName)) {
+        return activity;
+      }
+    }
+    return null;
+  }
+
+  /** Update an existing Activity. */
+  public void updateActivity(Activity activity) {
+    persistentStorageAgent.writeThrough(activity);
+  }
+
   /** Sets the List of Activities stored by this ActivityStore. */
   public void setActivities(List<Activity> activities) {
     this.activities = activities;

--- a/src/main/webapp/WEB-INF/view/activityfeed.jsp
+++ b/src/main/webapp/WEB-INF/view/activityfeed.jsp
@@ -3,8 +3,10 @@
 <%@ page import="codeu.model.data.Conversation" %>
 <%@ page import="codeu.model.data.Message" %>
 <%@ page import="codeu.model.data.Activity" %>
+<%@ page import="codeu.model.data.Utils" %>
 <%@ page import="codeu.model.data.Activity.ActivityType" %>
 <%@ page import="codeu.model.store.basic.UserStore" %>
+
 <%
 	List<Activity> activities = (List<Activity>) request.getAttribute("activities");
 	request.getSession().setAttribute("activities", activities );
@@ -57,12 +59,15 @@
 			String authorUrl = "/users/";
 			authorUrl += author;
 
+			String activityHour = Utils.getTime(activity.getCreationTime());
+			activityHour = activityHour.substring(activityHour.length()-8);
+
 			if (activity.getActivityType() == ActivityType.REGISTRATION) {
 
 
 	%>
 
-				<li><strong> <a href=<%= authorUrl %> > <%= author%></a>: </strong><%= activity.getMessage() %></li>
+				<li><strong> <a href=<%= authorUrl %> > <%= author%></a>: </strong><%= activity.getMessage() %> <small><sub> <%= activityHour %></sub></small> </li>
 
 	<%
 			} else if (activity.getActivityType() == ActivityType.CONVERSATION) {
@@ -70,10 +75,11 @@
 
 				String conversationUrl = "/chat/";
 				conversationUrl += conversation;
-
+				String conversationName = activity.getConversationName();
+				String messageCount = "" + (activity.getAllTimeCount() - 1);
 	%>
 
-				<li><strong> <a href=<%= authorUrl %> > <%= author%></a>: </strong><%= activity.getMessage() %> <strong> <a href=<%= conversationUrl %> > conversation </a> </strong>! </li>
+				<li><strong> <a href=<%= authorUrl %> > <%= author%></a>: </strong><%= activity.getMessage() %> <strong> <a href=<%= conversationUrl %> >conversation</a></strong>(<%= conversationName%>)<small><sub> <%= activityHour %> | message count: <%= messageCount %></sub></small> </li>
 
 	<%
 		}

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -17,9 +17,12 @@ package codeu.controller;
 import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
+import codeu.model.data.Activity;
+import codeu.model.data.Activity.ActivityType;
 import codeu.model.store.basic.ConversationStore;
 import codeu.model.store.basic.MessageStore;
 import codeu.model.store.basic.UserStore;
+import codeu.model.store.basic.ActivityStore;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -46,6 +49,7 @@ public class ChatServletTest {
   private ConversationStore mockConversationStore;
   private MessageStore mockMessageStore;
   private UserStore mockUserStore;
+  private ActivityStore mockActivityStore;
 
   @Before
   public void setup() {
@@ -68,6 +72,9 @@ public class ChatServletTest {
 
     mockUserStore = Mockito.mock(UserStore.class);
     chatServlet.setUserStore(mockUserStore);
+
+    mockActivityStore = Mockito.mock(ActivityStore.class);
+    chatServlet.setActivityStore(mockActivityStore);
   }
 
   @Test
@@ -167,6 +174,9 @@ public class ChatServletTest {
             false);
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
+    Activity fakeActivity = new Activity(UUID.randomUUID(), 1, Instant.ofEpochMilli(1000), "test_activity", UUID.randomUUID(), "test_user", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name");
+    Mockito.when(mockActivityStore.getActivityWithConversationName("test_conversation")).thenReturn(fakeActivity);
+
     Conversation fakeConversation =
         new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), false);
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
@@ -196,6 +206,9 @@ public class ChatServletTest {
             Instant.now(),
             false);
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
+
+    Activity fakeActivity = new Activity(UUID.randomUUID(), 1, Instant.ofEpochMilli(1000), "test_activity", UUID.randomUUID(), "test_user", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name");
+    Mockito.when(mockActivityStore.getActivityWithConversationName("test_conversation")).thenReturn(fakeActivity);
 
     Conversation fakeConversation =
         new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now(), false);


### PR DESCRIPTION
Before these changes are implemented it would be best to delete the current collection of Activities, Conversations, and Messages in datastore (both locally and otherwise http://localhost:8080/_ah/admin). Otherwise you will probably get errors when posting messages!

Deleting the current collection of users from datastore isn't necessary, but all pre-existing users might lose the initial (user joined!) Activity object if all Activity objects are deleted.

*ActivityStore.java
++Added a method that returns the Activity associated with a Conversation name
++Added a method that updates an Activity object in datastore

*ChatServlet.java
++When a new message is posted to a conversation, the Activity object associated with that conversation has its allTimeCount field increased by one and that object is updated in datastore.

*ActivityFeed.jsp
++Page displays the creation time of an activity and the message count of a conversation
(Let me know if there are any further changes you would like to see to the activity feed display or if anything looks off or confusing)