### PR TITLE
Padraic development

### DIFF
--- a/src/main/java/codeu/controller/ActivityFeedServlet.java
+++ b/src/main/java/codeu/controller/ActivityFeedServlet.java
@@ -87,6 +87,12 @@ public class ActivityFeedServlet extends HttpServlet {
         request.setAttribute("checked", "popular");
       } else if (toggle.equals("recent")) {
         request.setAttribute("checked", "recent");
+      } else if (toggle.equals("trend")) {
+        request.setAttribute("checked", "trend");
+      } else if (toggle.equals("daily")) {
+        request.setAttribute("checked", "daily");
+      } else if (toggle.equals("today")) {
+        request.setAttribute("checked", "today");
       }
 
       }
@@ -102,6 +108,21 @@ public class ActivityFeedServlet extends HttpServlet {
       sortByRecency(activities);
       request.setAttribute("checked", "recent");
 
+    } else if (sortingStyle.equals("trend") || toggle.equals("trend")) {
+
+      sortByTrend(activities);
+      request.setAttribute("checked", "trend");
+
+    } else if (sortingStyle.equals("daily") || toggle.equals("daily")) {
+
+      sortByDaily(activities);
+      request.setAttribute("checked", "daily");
+
+    } else if (sortingStyle.equals("today") || toggle.equals("today")) {
+
+      sortByToday(activities);
+      request.setAttribute("checked", "today");
+
     }
 
     request.setAttribute("activities", activities);
@@ -112,6 +133,21 @@ public class ActivityFeedServlet extends HttpServlet {
   /*Sorts activities by allTimeCount field*/
   void sortByPopularity(List<Activity> activities) {
     Collections.sort(activities, (one, other) -> other.getAllTimeCount() - one.getAllTimeCount());
+  }
+
+  /*Sorts activities by their popularity 'today'*/
+  void sortByToday(List<Activity> activities) {
+    Collections.sort(activities, (one, other) -> Double.compare(other.getPopularityToday(), one.getPopularityToday()));
+  }
+
+  /*Sorts activities by their daily average*/
+  void sortByDaily(List<Activity> activities) {
+    Collections.sort(activities, (one, other) -> Double.compare(other.calculateMean(), one.calculateMean()));
+  }
+
+  /*Sorts activities by their zScore field*/
+  void sortByTrend(List<Activity> activities) {
+    Collections.sort(activities, (one, other) -> Double.compare(other.getZScore(), one.getZScore()));
   }
 
   /*Sorts activities by creationTime field*/

--- a/src/main/java/codeu/controller/ActivityFeedServlet.java
+++ b/src/main/java/codeu/controller/ActivityFeedServlet.java
@@ -89,7 +89,7 @@ public class ActivityFeedServlet extends HttpServlet {
         request.setAttribute("checked", "recent");
       }
 
-    }
+      }
 
 
     if(sortingStyle.equals("popular") || toggle.equals("popular")) {

--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -233,9 +233,11 @@ private ActivityStore activityStore;
     if (!conversation.getPrivate()) {
       Activity conversationActivity = activityStore.getActivityWithConversationName(conversationTitle);
       conversationActivity.increaseAllTimeCount();
+      conversationActivity.increaseDailyPopularity();
+      conversationActivity.setZScore();
       activityStore.updateActivity(conversationActivity);
     }
-    
+
     // redirect to a GET request
     response.sendRedirect("/chat/" + conversationTitle);
   }

--- a/src/main/java/codeu/controller/ConversationServlet.java
+++ b/src/main/java/codeu/controller/ConversationServlet.java
@@ -133,7 +133,7 @@ public class ConversationServlet extends HttpServlet {
 
     conversationStore.addConversation(conversation);
 
-    Activity activity = new Activity(UUID.randomUUID(), 1, Instant.now(), "started a new ", user.getId(), user.getName(), ActivityType.CONVERSATION, conversation.getId(), conversation.getTitle());
+    Activity activity = new Activity(UUID.randomUUID(), 1, Instant.now(), "started a new ", user.getId(), user.getName(), ActivityType.CONVERSATION, conversation.getId(), conversation.getTitle(), new double[4], 0);
     activityStore.addActivity(activity);
 
     response.sendRedirect("/chat/" + conversationTitle);

--- a/src/main/java/codeu/controller/RegisterServlet.java
+++ b/src/main/java/codeu/controller/RegisterServlet.java
@@ -108,7 +108,7 @@ public class RegisterServlet extends HttpServlet {
     User user = new User(UUID.randomUUID(), username, hashedPassword, email, Instant.now(), false);
     userStore.addUser(user);
 
-    Activity activity = new Activity(UUID.randomUUID(), 0, Instant.now(), "joined the site!", user.getId(), user.getName(), ActivityType.REGISTRATION, null, null);
+    Activity activity = new Activity(UUID.randomUUID(), 0, Instant.now(), "joined the site!", user.getId(), user.getName(), ActivityType.REGISTRATION, null, null, new double[4], -50);
 
     activityStore.addActivity(activity);
 

--- a/src/main/java/codeu/controller/ServerStartupListener.java
+++ b/src/main/java/codeu/controller/ServerStartupListener.java
@@ -66,14 +66,14 @@ public class ServerStartupListener implements ServletContextListener {
        ServerStartupTimes originalServerStartupTimes = serverStartupTimesStore.getServerStartupTimes();
 
       if (originalServerStartupTimes.compareStartupTimes24()) {
-        activities = PersistentStorageAgent.getInstance().loadActivities();
+        activities = PersistentStorageAgent.getInstance().loadActivities(true);
         UUID originalId = originalServerStartupTimes.getServerStartupTimesId();
         ServerStartupTimes newServerStartupTimes = new ServerStartupTimes(originalId, currentServerStartupTime, currentServerStartupTime);
         serverStartupTimesStore.setServerStartupTimes(newServerStartupTimes);
         PersistentStorageAgent.getInstance().writeThrough(newServerStartupTimes);
 
       } else {
-        activities = PersistentStorageAgent.getInstance().loadActivities();
+        activities = PersistentStorageAgent.getInstance().loadActivities(false);
       }
 
 

--- a/src/main/java/codeu/controller/ServerStartupListener.java
+++ b/src/main/java/codeu/controller/ServerStartupListener.java
@@ -16,6 +16,8 @@ import java.util.List;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import java.time.temporal.ChronoUnit;
+
 import org.mindrot.jbcrypt.BCrypt;
 
 import java.time.Instant;
@@ -46,24 +48,31 @@ public class ServerStartupListener implements ServletContextListener {
       ServerStartupTimes serverStartupTimes = PersistentStorageAgent.getInstance().loadServerStartupTimes();
       serverStartupTimesStore.setServerStartupTimes(serverStartupTimes);
 
-      UUID serverStartupTimesId = serverStartupTimesStore.getServerStartupTimes().getServerStartupTimesId();
+      UUID serverStartupTimesId = serverStartupTimes.getServerStartupTimesId();
 
       /** If the ServerStartupTimes in ServerStartupTimes Store hasn't been initialized,
         * this will initialize it. Should only ever happen once.
         */
+
       if (serverStartupTimesId == null) {
         ServerStartupTimes initServerStartupTimes = new ServerStartupTimes(UUID.randomUUID(), currentServerStartupTime, currentServerStartupTime);
         serverStartupTimesStore.setServerStartupTimes(initServerStartupTimes);
         PersistentStorageAgent.getInstance().writeThrough(initServerStartupTimes);
+        serverStartupTimes = initServerStartupTimes;
       }
-
 
       /** Check to see if at least a 'day' has passed, if it has load Activities in a special
        * way that shifts the weekly popularity variables and reevalutes every item's trending
        * count.
        */
-        List<Activity> activities;
+
+       serverStartupTimes.setCurrentServerStartupTime(currentServerStartupTime);
+       serverStartupTimesStore.updateServerStartupTimes(serverStartupTimes);
+
+       List<Activity> activities;
        ServerStartupTimes originalServerStartupTimes = serverStartupTimesStore.getServerStartupTimes();
+
+       System.out.println(originalServerStartupTimes.compareStartupTimes24());
 
       if (originalServerStartupTimes.compareStartupTimes24()) {
         activities = PersistentStorageAgent.getInstance().loadActivities(true);

--- a/src/main/java/codeu/model/data/Activity.java
+++ b/src/main/java/codeu/model/data/Activity.java
@@ -60,6 +60,23 @@ public class Activity implements Serializable {
   private final String conversationName;
 
   /**
+   * Gives the day by day popularity of an activity object
+   * The third index in the array represents the current 'day',
+   * while every other index represents the previous 3 'days'
+   */
+
+  private double[] dailyPopularity;
+
+  /**
+   * Gives the z-score of an activty, which represents
+   * how many standard deviations its popularity for the day (3rd index of dailyPopularity),
+   * is above or below it's mean popularity for the last 4 'days' (all indexes of dailyPopularity)
+   * Used to determine an activity's trend
+   */
+
+  private double zScore;
+
+  /**
    * Constructs a new Activity.
    *
    * @param activityId the ID of this activity
@@ -70,7 +87,7 @@ public class Activity implements Serializable {
    * @param username the username of the user associated with this activity
    * @param
    */
-  public Activity(UUID activityId, int allTimeCount, Instant creation, String message, UUID userId, String username, ActivityType type, UUID conversationId, String conversationName) {
+  public Activity(UUID activityId, int allTimeCount, Instant creation, String message, UUID userId, String username, ActivityType type, UUID conversationId, String conversationName, double[] dailyPopularity, double zScore) {
     this.activityId = activityId;
     this.allTimeCount = allTimeCount;
     this.creation = creation;
@@ -80,6 +97,8 @@ public class Activity implements Serializable {
     this.type = type;
     this.conversationId = conversationId;
     this.conversationName = conversationName;
+    this.dailyPopularity = dailyPopularity;
+    this.zScore = zScore;
 
   }
 
@@ -128,11 +147,71 @@ public class Activity implements Serializable {
     return conversationName;
   }
 
+  /** Returns 'today's' popularity count (third index in dailyPopularity)*/
+  public double getPopularityToday() {
+    return dailyPopularity[3];
+  }
+
+  public double[] getDailyPopularity() {
+    return dailyPopularity;
+  }
+
+  /** Returns the zScore of an Activity */
+  public double getZScore() {
+    return zScore;
+  }
+
+  /** Increases the allTimeCount field of an Activity by 1 */
   public void increaseAllTimeCount() {
     allTimeCount += 1;
   }
 
+  /** Increases the popularity count for the current day (3rd index of dailyPopularity) */
+  public void increaseDailyPopularity() {
+    this.dailyPopularity[3] += 1;
+  }
+
+  /** Sets the zScore for an activity object based on its dailyPopularity */
+  public void setZScore() {
+    if (this.calculateStandardDeviation() != 0) {
+      this.zScore = this.calculateZScore();
+    } else {
+      this.zScore = 0;
+    }
+  }
+
+  /** Setter for the message field of an Activity */
   public void setMessage(String newMessage) {
     message = newMessage;
+  }
+
+  /** Calculates the mean of the dailyPopularity array field */
+  private double calculateMean() {
+    double sum = 0.0;
+      for(double num : dailyPopularity) {
+        sum += num;
+      }
+
+      double mean = sum/dailyPopularity.length;
+
+      return mean;
+  }
+
+  /** calculates the standard deviation of the dailyPopularity array */
+  private double calculateStandardDeviation() {
+    double mean = this.calculateMean();
+    double standardDeviation = 0.0;
+
+    for(double num: dailyPopularity) {
+      standardDeviation += Math.pow(num - mean, 2);
+    }
+
+    return Math.sqrt(standardDeviation/dailyPopularity.length);
+  }
+
+  /** Calculates the ZScore of the dailyPopularity array field */
+  private double calculateZScore() {
+    double zScore = (this.getPopularityToday() - this.calculateMean())/this.calculateStandardDeviation();
+    return zScore;
   }
 }

--- a/src/main/java/codeu/model/data/Activity.java
+++ b/src/main/java/codeu/model/data/Activity.java
@@ -205,7 +205,8 @@ public class Activity implements Serializable {
     for(double num: dailyPopularity) {
       standardDeviation += Math.pow(num - mean, 2);
     }
-
+    System.out.println(Math.sqrt(standardDeviation/dailyPopularity.length));
+    System.out.println(mean);
     return Math.sqrt(standardDeviation/dailyPopularity.length);
   }
 

--- a/src/main/java/codeu/model/data/Activity.java
+++ b/src/main/java/codeu/model/data/Activity.java
@@ -186,7 +186,7 @@ public class Activity implements Serializable {
   }
 
   /** Calculates the mean of the dailyPopularity array field */
-  private double calculateMean() {
+  public double calculateMean() {
     double sum = 0.0;
       for(double num : dailyPopularity) {
         sum += num;

--- a/src/main/java/codeu/model/data/ServerStartupTimes.java
+++ b/src/main/java/codeu/model/data/ServerStartupTimes.java
@@ -1,0 +1,77 @@
+package codeu.model.data;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.time.Duration;
+
+/**
+  * A Class containing two instants in time: A reference instant that is used to determine
+  * if at least 24 hours has passed since the last 'day' the app was active, and a 'current' instance
+  * that contains the first instant the server was started in the current session.
+  * In the server startup listener when at least 24 hours has passed between currentServerStartupTime
+  * and referenceServerStartupTime, currentServerStartupTime becomes the new referenceServerStartuptime.
+  */
+
+public class ServerStartupTimes {
+
+  /** the unique ID of the singular ServerStartupTimes object **/
+  private final UUID serverStartupTimesId;
+
+  /** the reference instant used to determine when at least 24 hours (a 'day') has passed in the app */
+  private Instant referenceServerStartupTime;
+
+  /** the first instant that the server was started up for the current session */
+  private Instant currentServerStartupTime;
+
+  /**
+    * Constructs a new ServerStartupTime
+    * @param serverStartupTimesId the unique Id of the serverStartupTimes instance
+    * @param referenceServerStartupTime the last instant the server was started up before 'today'
+    * @param currentServerStartupTime the first instant that the server was started up for the current session
+    */
+
+  public ServerStartupTimes(UUID serverStartupTimesId, Instant referenceServerStartupTime, Instant currentServerStartupTime) {
+    this.serverStartupTimesId = serverStartupTimesId;
+    this.referenceServerStartupTime = referenceServerStartupTime;
+    this.currentServerStartupTime = currentServerStartupTime;
+  }
+
+  /**
+    * Used to check if 24 hours has passed between the currentServerStartupTime
+    * and referenceServerStartupTime fields.
+    */
+
+  public boolean compareStartupTimes24() {
+
+    long timePassed = Duration.between(referenceServerStartupTime, currentServerStartupTime).toHours();
+
+    return timePassed >= 24;
+
+  }
+
+  /** Setter for the referenceServerStartupTime attribute */
+  public void setReferenceServerStartupTime(Instant newReferenceServerStartupTime) {
+    this.referenceServerStartupTime = newReferenceServerStartupTime;
+  }
+
+  /** Setter for the currentServerxStartupTime attribute */
+  public void setCurrentServerStartupTime(Instant newCurrentServerStartupTime) {
+    this.currentServerStartupTime = newCurrentServerStartupTime;
+  }
+
+  /** Returns the unique id of the ServerStartupTimes object */
+  public UUID getServerStartupTimesId() {
+    return serverStartupTimesId;
+  }
+
+  /** Returns the referenceServerStartupTime attribute */
+  public Instant getReferenceServerStartupTime() {
+    return referenceServerStartupTime;
+  }
+
+  /** Returns the currentServerStartupTime attribute */
+  public Instant getCurrentServerStartupTime() {
+    return currentServerStartupTime;
+  }
+
+}

--- a/src/main/java/codeu/model/store/basic/ServerStartupTimesStore.java
+++ b/src/main/java/codeu/model/store/basic/ServerStartupTimesStore.java
@@ -1,0 +1,67 @@
+package codeu.model.store.basic;
+
+import codeu.model.data.ServerStartupTimes;
+import codeu.model.store.persistence.PersistentStorageAgent;
+import java.util.UUID;
+
+/**
+ * Store class that uses in-memory data structures to hold values and automatically loads from
+ * and saves to PersistentStorageAgent. It's a singleton so all servlet classes can access
+ * the same instance.
+ */
+
+public class ServerStartupTimesStore {
+
+  /** Singleton instance of ServerStartupTimesStore. */
+  private static ServerStartupTimesStore instance;
+
+  /**
+   * Returns the singleton instance of ServerStartupTimesStore that should be shared between all
+   * servlet classes. Do not call this function from a test; use getTestInstance() instead.
+   */
+  public static ServerStartupTimesStore getInstance() {
+    if (instance == null) {
+      instance = new ServerStartupTimesStore(PersistentStorageAgent.getInstance());
+    }
+    return instance;
+  }
+
+  /**
+   * Instance getter function used for testing. Supply a mock for PersistentStorageAgent.
+   *
+   * @param persistentStorageAgent a mock used for testing
+   */
+  public static ServerStartupTimesStore getTestInstance(PersistentStorageAgent persistentStorageAgent) {
+    return new ServerStartupTimesStore(persistentStorageAgent);
+  }
+
+  /**
+   * The PersistentStorageAgent responsible for loading Activities from and saving Activities
+   * to Datastore.
+   */
+  private PersistentStorageAgent persistentStorageAgent;
+
+  /** The in-memory instance of ServerStartupTimes */
+  private ServerStartupTimes serverStartupTimes;
+
+  /** This class is a singleton, so its constructor is private. Call getInstance() instead. */
+  private ServerStartupTimesStore(PersistentStorageAgent persistentStorageAgent) {
+    this.persistentStorageAgent = persistentStorageAgent;
+  }
+
+  /** Return the serverStartupTime found in this  */
+  public ServerStartupTimes getServerStartupTimes() {
+    return serverStartupTimes;
+  }
+
+
+  /** Update the activity feed's instance of serverStartupTimes. */
+  public void updateServerStartupTimes(ServerStartupTimes serverStartupTimes) {
+    persistentStorageAgent.writeThrough(serverStartupTimes);
+  }
+
+  /** Sets the List of Activities stored by this ActivityStore. */
+  public void setServerStartupTimes(ServerStartupTimes serverStartupTimes) {
+    this.serverStartupTimes = serverStartupTimes;
+  }
+}

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -205,7 +205,7 @@ public class PersistentDataStore {
    * @throws PersistentDataStoreException if an error was detected during the load from the
    *     Datastore service
    */
-  public List<Activity> loadActivities() throws PersistentDataStoreException {
+  public List<Activity> loadActivities(boolean newDay) throws PersistentDataStoreException {
 
     List<Activity> activities = new ArrayList<>();
 
@@ -229,14 +229,25 @@ public class PersistentDataStore {
         String conversationName = (String) entity.getProperty("conversation_name");
 
         double[] dailyPopularity = new double[4];
-        dailyPopularity[0] = Double.parseDouble((String) entity.getProperty("dailyPopularity[0]"));
-        dailyPopularity[1] = Double.parseDouble((String) entity.getProperty("dailyPopularity[1]"));
-        dailyPopularity[2] = Double.parseDouble((String) entity.getProperty("dailyPopularity[2]"));
-        dailyPopularity[3] = Double.parseDouble((String) entity.getProperty("dailyPopularity[3]"));
 
         double zScore = Double.parseDouble((String) entity.getProperty("zScore"));
 
+        if (newDay) {
+          dailyPopularity[0] = Double.parseDouble((String) entity.getProperty("dailyPopularity[1]"));
+          dailyPopularity[1] = Double.parseDouble((String) entity.getProperty("dailyPopularity[2]"));
+          dailyPopularity[2] = Double.parseDouble((String) entity.getProperty("dailyPopularity[3]"));
+          dailyPopularity[3] = 0;
+        } else {
+          dailyPopularity[0] = Double.parseDouble((String) entity.getProperty("dailyPopularity[0]"));
+          dailyPopularity[1] = Double.parseDouble((String) entity.getProperty("dailyPopularity[1]"));
+          dailyPopularity[2] = Double.parseDouble((String) entity.getProperty("dailyPopularity[2]"));
+          dailyPopularity[3] = Double.parseDouble((String) entity.getProperty("dailyPopularity[3]"));
+        }
+
         Activity activity = new Activity(activityUuid, allTimeCount, creationTime, message, userUuid, username, type, conversationId, conversationName, dailyPopularity, zScore);
+        if(newDay) {
+          activity.setZScore();
+        }
         activities.add(activity);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -251,15 +251,15 @@ public class PersistentDataStore {
         }
         activities.add(activity);
 
-      } catch (Exception e) {
-        // In a production environment, errors should be very rare. Errors which may
-        // occur include network errors, Datastore service errors, authorization errors,
-        // database entity definition mismatches, or service mismatches.
-        throw new PersistentDataStoreException(e);
+        } catch (Exception e) {
+          // In a production environment, errors should be very rare. Errors which may
+          // occur include network errors, Datastore service errors, authorization errors,
+          // database entity definition mismatches, or service mismatches.
+          throw new PersistentDataStoreException(e);
+        }
       }
-    }
 
-    return activities;
+      return activities;
   }
 
   /** Write a User object to the Datastore service. */

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -228,7 +228,15 @@ public class PersistentDataStore {
         }
         String conversationName = (String) entity.getProperty("conversation_name");
 
-        Activity activity = new Activity(activityUuid, allTimeCount, creationTime, message, userUuid, username, type, conversationId, conversationName);
+        double[] dailyPopularity = new double[4];
+        dailyPopularity[0] = Double.parseDouble((String) entity.getProperty("dailyPopularity[0]"));
+        dailyPopularity[1] = Double.parseDouble((String) entity.getProperty("dailyPopularity[1]"));
+        dailyPopularity[2] = Double.parseDouble((String) entity.getProperty("dailyPopularity[2]"));
+        dailyPopularity[3] = Double.parseDouble((String) entity.getProperty("dailyPopularity[3]"));
+
+        double zScore = Double.parseDouble((String) entity.getProperty("zScore"));
+
+        Activity activity = new Activity(activityUuid, allTimeCount, creationTime, message, userUuid, username, type, conversationId, conversationName, dailyPopularity, zScore);
         activities.add(activity);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
@@ -296,6 +304,15 @@ public class PersistentDataStore {
       activityEntity.setProperty("conversation_uuid", activity.getConversationId().toString());
     }
     activityEntity.setProperty("conversation_name", activity.getConversationName());
+
+    /** Write each member of dailyPopularity array seperately */
+    activityEntity.setProperty("dailyPopularity[0]", Double.toString(activity.getDailyPopularity()[0]));
+    activityEntity.setProperty("dailyPopularity[1]", Double.toString(activity.getDailyPopularity()[1]));
+    activityEntity.setProperty("dailyPopularity[2]", Double.toString(activity.getDailyPopularity()[2]));
+    activityEntity.setProperty("dailyPopularity[3]", Double.toString(activity.getDailyPopularity()[3]));
+
+    activityEntity.setProperty("zScore", Double.toString(activity.getZScore()));
+
     datastore.put(activityEntity);
   }
 

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -232,7 +232,7 @@ public class PersistentDataStore {
 
         double zScore = Double.parseDouble((String) entity.getProperty("zScore"));
 
-        if (newDay) {
+        if (newDay && type == ActivityType.CONVERSATION) {
           dailyPopularity[0] = Double.parseDouble((String) entity.getProperty("dailyPopularity[1]"));
           dailyPopularity[1] = Double.parseDouble((String) entity.getProperty("dailyPopularity[2]"));
           dailyPopularity[2] = Double.parseDouble((String) entity.getProperty("dailyPopularity[3]"));
@@ -245,10 +245,12 @@ public class PersistentDataStore {
         }
 
         Activity activity = new Activity(activityUuid, allTimeCount, creationTime, message, userUuid, username, type, conversationId, conversationName, dailyPopularity, zScore);
-        if(newDay) {
+        if(newDay && type == ActivityType.CONVERSATION) {
           activity.setZScore();
+          this.writeThrough(activity);
         }
         activities.add(activity);
+
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may
         // occur include network errors, Datastore service errors, authorization errors,

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -100,8 +100,8 @@ public class PersistentStorageAgent {
 	 *	Datastore service
    */
 
-  public List<Activity> loadActivities() throws PersistentDataStoreException {
-    return persistentDataStore.loadActivities();
+  public List<Activity> loadActivities(boolean newDay) throws PersistentDataStoreException {
+    return persistentDataStore.loadActivities(newDay);
   }
 
   /**

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -19,6 +19,7 @@ import codeu.model.data.Message;
 import codeu.model.data.User;
 import codeu.model.data.Activity;
 import codeu.model.data.Activity.ActivityType;
+import codeu.model.data.ServerStartupTimes;
 import codeu.model.store.persistence.PersistentDataStore;
 import java.util.List;
 
@@ -82,15 +83,16 @@ public class PersistentStorageAgent {
   }
 
 	/**
-	 * Retrieve the Activity Feed's conversation object from the Datastore service.
+	 * Retrieve the ServerStartupTimes object from the Datastore service.
 	 *
 	 *@throws PersistentDataStoreException if an error was detected during the load from the
 	 *	Datastore service
    */
 
-	public Conversation loadActFeedConversation() throws PersistentDataStoreException {
-		return persistentDataStore.loadActFeedConversation();
+	public ServerStartupTimes loadServerStartupTimes() throws PersistentDataStoreException {
+		return persistentDataStore.loadServerStartupTimes();
 	}
+
   /**
 	 * Retrieve all Activity Feed objects from the Datastore service. The returned list may be empty.
 	 *
@@ -130,5 +132,10 @@ public class PersistentStorageAgent {
   /** Write an Activity object to the Datastore service. */
   public void writeThrough(Activity activity) {
     persistentDataStore.writeThrough(activity);
+  }
+
+  /** Write a ServerStartupTimes object to the Datastore service. */
+  public void writeThrough(ServerStartupTimes serverStartupTimes) {
+    persistentDataStore.writeThrough(serverStartupTimes);
   }
 }

--- a/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentStorageAgent.java
@@ -82,22 +82,22 @@ public class PersistentStorageAgent {
     return persistentDataStore.loadConversations();
   }
 
-	/**
-	 * Retrieve the ServerStartupTimes object from the Datastore service.
-	 *
-	 *@throws PersistentDataStoreException if an error was detected during the load from the
-	 *	Datastore service
+ /**
+   * Retrieve the ServerStartupTimes object from the Datastore service.
+   *
+   *@throws PersistentDataStoreException if an error was detected during the load from the
+   *	Datastore service
    */
 
-	public ServerStartupTimes loadServerStartupTimes() throws PersistentDataStoreException {
-		return persistentDataStore.loadServerStartupTimes();
-	}
+  public ServerStartupTimes loadServerStartupTimes() throws PersistentDataStoreException {
+    return persistentDataStore.loadServerStartupTimes();
+  }
 
-  /**
-	 * Retrieve all Activity Feed objects from the Datastore service. The returned list may be empty.
-	 *
-	 *@throws PersistentDataStoreException if an error was detected during the load from the
-	 *	Datastore service
+ /**
+   * Retrieve all Activity Feed objects from the Datastore service. The returned list may be empty.
+   *
+   *@throws PersistentDataStoreException if an error was detected during the load from the
+   *	Datastore service
    */
 
   public List<Activity> loadActivities(boolean newDay) throws PersistentDataStoreException {

--- a/src/main/webapp/WEB-INF/view/activityfeed.jsp
+++ b/src/main/webapp/WEB-INF/view/activityfeed.jsp
@@ -46,6 +46,9 @@
 			<form id="sortingForm" action="/activityfeed" method= "POST">
 					<input type="radio" id="recencySort" name="sortingStyle" onclick="callServlet('POST')" value="recent" <%= checked != null && checked.equals("recent")? "checked":""%> > Recent
 					<input type="radio" id="popularitySort" name="sortingStyle" onclick="callServlet('POST')" value="popular" <%= checked != null && checked.equals("popular")? "checked":""%> > Popular
+					<input type="radio" id="trendSort" name="sortingStyle" onclick="callServlet('POST')" value="trend" <%= checked != null && checked.equals("trend")? "checked":""%> > Trending
+					<input type="radio" id="dailySort" name="sortingStyle" onclick="callServlet('POST')" value="daily" <%= checked != null && checked.equals("daily")? "checked":""%> > Popular this Week
+					<input type="radio" id="todaySort" name="sortingStyle" onclick="callServlet('POST')" value="today" <%= checked != null && checked.equals("today")? "checked":""%> > Popular Today
 			</form>
 
 		</div>

--- a/src/main/webapp/WEB-INF/view/activityfeed.jsp
+++ b/src/main/webapp/WEB-INF/view/activityfeed.jsp
@@ -63,7 +63,7 @@
 			authorUrl += author;
 
 			String activityHour = Utils.getTime(activity.getCreationTime());
-			activityHour = activityHour.substring(activityHour.length()-8);
+			activityHour = activityHour.charAt(0) + activityHour.substring(1, activityHour.length()).toLowerCase();
 
 			if (activity.getActivityType() == ActivityType.REGISTRATION) {
 

--- a/src/test/java/codeu/controller/ActivityFeedServletTest.java
+++ b/src/test/java/codeu/controller/ActivityFeedServletTest.java
@@ -69,7 +69,7 @@ public class ActivityFeedServletTest {
   }
 
   @Test
-  public void testDoPost() throws IOException, ServletException {
+  public void testDoPostSearch() throws IOException, ServletException {
     List<Activity> fakeActivityList = new ArrayList<>();
     Activity fakeActivity =  new Activity(UUID.randomUUID(), 0, Instant.now(), "test_activity", UUID.randomUUID(), "test_username",
       ActivityType.REGISTRATION, null, null);

--- a/src/test/java/codeu/controller/ActivityFeedServletTest.java
+++ b/src/test/java/codeu/controller/ActivityFeedServletTest.java
@@ -56,7 +56,7 @@ public class ActivityFeedServletTest {
 
     List<Activity> fakeActivityList = new ArrayList<>();
     Activity fakeActivity =  new Activity(UUID.randomUUID(), 0, Instant.now(), "test_activity", UUID.randomUUID(), "test_username",
-      ActivityType.REGISTRATION, null, null);
+      ActivityType.REGISTRATION, null, null, new double[4], 0);
     fakeActivityList.add(fakeActivity);
 
     Mockito.when(mockActivityStore.getActivities()).thenReturn(fakeActivityList);
@@ -72,7 +72,7 @@ public class ActivityFeedServletTest {
   public void testDoPostSearch() throws IOException, ServletException {
     List<Activity> fakeActivityList = new ArrayList<>();
     Activity fakeActivity =  new Activity(UUID.randomUUID(), 0, Instant.now(), "test_activity", UUID.randomUUID(), "test_username",
-      ActivityType.REGISTRATION, null, null);
+      ActivityType.REGISTRATION, null, null, new double[4], 0);
     fakeActivityList.add(fakeActivity);
 
     Mockito.when(mockRequest.getParameter("searchQuery")).thenReturn("test_activity");
@@ -92,7 +92,7 @@ public class ActivityFeedServletTest {
   public void testDoPostUncleanedSearchQuery() throws IOException, ServletException {
     List<Activity> fakeActivityList = new ArrayList<>();
     Activity fakeActivity =  new Activity(UUID.randomUUID(), 0, Instant.now(), "test_activity", UUID.randomUUID(), "test_username",
-      ActivityType.REGISTRATION, null, null);
+      ActivityType.REGISTRATION, null, null, new double[4], 0);
     fakeActivityList.add(fakeActivity);
 
     Mockito.when(mockRequest.getParameter("searchQuery")).thenReturn("<h1> test_activity <h1>");

--- a/src/test/java/codeu/controller/ActivityFeedServletTest.java
+++ b/src/test/java/codeu/controller/ActivityFeedServletTest.java
@@ -56,7 +56,7 @@ public class ActivityFeedServletTest {
 
     List<Activity> fakeActivityList = new ArrayList<>();
     Activity fakeActivity =  new Activity(UUID.randomUUID(), 0, Instant.now(), "test_activity", UUID.randomUUID(), "test_username",
-      ActivityType.REGISTRATION, null, null, new double[4], 0);
+    ActivityType.REGISTRATION, null, null, new double[4], 0);
     fakeActivityList.add(fakeActivity);
 
     Mockito.when(mockActivityStore.getActivities()).thenReturn(fakeActivityList);
@@ -72,7 +72,7 @@ public class ActivityFeedServletTest {
   public void testDoPostSearch() throws IOException, ServletException {
     List<Activity> fakeActivityList = new ArrayList<>();
     Activity fakeActivity =  new Activity(UUID.randomUUID(), 0, Instant.now(), "test_activity", UUID.randomUUID(), "test_username",
-      ActivityType.REGISTRATION, null, null, new double[4], 0);
+    ActivityType.REGISTRATION, null, null, new double[4], 0);
     fakeActivityList.add(fakeActivity);
 
     Mockito.when(mockRequest.getParameter("searchQuery")).thenReturn("test_activity");
@@ -92,7 +92,7 @@ public class ActivityFeedServletTest {
   public void testDoPostUncleanedSearchQuery() throws IOException, ServletException {
     List<Activity> fakeActivityList = new ArrayList<>();
     Activity fakeActivity =  new Activity(UUID.randomUUID(), 0, Instant.now(), "test_activity", UUID.randomUUID(), "test_username",
-      ActivityType.REGISTRATION, null, null, new double[4], 0);
+    ActivityType.REGISTRATION, null, null, new double[4], 0);
     fakeActivityList.add(fakeActivity);
 
     Mockito.when(mockRequest.getParameter("searchQuery")).thenReturn("<h1> test_activity <h1>");

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -175,7 +175,7 @@ public class ChatServletTest {
             false);
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
-    Activity fakeActivity = new Activity(UUID.randomUUID(), 1, Instant.ofEpochMilli(1000), "test_activity", UUID.randomUUID(), "test_user", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name");
+    Activity fakeActivity = new Activity(UUID.randomUUID(), 1, Instant.ofEpochMilli(1000), "test_activity", UUID.randomUUID(), "test_user", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name", new double[4], 0);
     Mockito.when(mockActivityStore.getActivityWithConversationName("test_conversation")).thenReturn(fakeActivity);
 
     Conversation fakeConversation =
@@ -208,7 +208,7 @@ public class ChatServletTest {
             false);
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
-    Activity fakeActivity = new Activity(UUID.randomUUID(), 1, Instant.ofEpochMilli(1000), "test_activity", UUID.randomUUID(), "test_user", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name");
+    Activity fakeActivity = new Activity(UUID.randomUUID(), 1, Instant.ofEpochMilli(1000), "test_activity", UUID.randomUUID(), "test_user", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name", new double[4], 0);
     Mockito.when(mockActivityStore.getActivityWithConversationName("test_conversation")).thenReturn(fakeActivity);
 
     Conversation fakeConversation =

--- a/src/test/java/codeu/model/data/ActivityTest.java
+++ b/src/test/java/codeu/model/data/ActivityTest.java
@@ -40,6 +40,7 @@ public class ActivityTest {
     Assert.assertEquals(dailyPopularity[3], activity.getPopularityToday(), 0.0001);
     Assert.assertEquals(dailyPopularity, activity.getDailyPopularity());
     Assert.assertEquals(zScore, activity.getZScore(), 0.0001);
+    Assert.assertEquals(6.0, activity.calculateMean(), 0.0001);
     activity.setZScore();
     Assert.assertEquals(0.63246, activity.getZScore(), 0.0001);
 

--- a/src/test/java/codeu/model/data/ActivityTest.java
+++ b/src/test/java/codeu/model/data/ActivityTest.java
@@ -20,7 +20,7 @@ public class ActivityTest {
     ActivityType type = ActivityType.CONVERSATION;
     UUID conversationId = UUID.randomUUID();
     String conversationName = "Test_Conversation_Name";
-    double[] dailyPopularity = {4, 2, 10, 8};
+    double[] dailyPopularity = {4.0, 2.0, 10.0, 8.0};
     double zScore = -1;
 
     Activity activity = new Activity(activityId, allTimeCount, creation, message, userId, username, type, conversationId, conversationName, dailyPopularity, zScore);
@@ -40,9 +40,13 @@ public class ActivityTest {
     Assert.assertEquals(dailyPopularity[3], activity.getPopularityToday(), 0.0001);
     Assert.assertEquals(dailyPopularity, activity.getDailyPopularity());
     Assert.assertEquals(zScore, activity.getZScore(), 0.0001);
+    activity.setZScore();
+    Assert.assertEquals(0.63246, activity.getZScore(), 0.0001);
 
     activity.increaseDailyPopularity();
-    Assert.assertEquals(9, activity.getPopularityToday(), 0.0001);
+    Assert.assertEquals(9.0, activity.getPopularityToday(), 0.0001);
+
+
 
   }
 }

--- a/src/test/java/codeu/model/data/ActivityTest.java
+++ b/src/test/java/codeu/model/data/ActivityTest.java
@@ -20,8 +20,10 @@ public class ActivityTest {
     ActivityType type = ActivityType.CONVERSATION;
     UUID conversationId = UUID.randomUUID();
     String conversationName = "Test_Conversation_Name";
+    double[] dailyPopularity = {4, 2, 10, 8};
+    double zScore = -1;
 
-    Activity activity = new Activity(activityId, allTimeCount, creation, message, userId, username, type, conversationId, conversationName);
+    Activity activity = new Activity(activityId, allTimeCount, creation, message, userId, username, type, conversationId, conversationName, dailyPopularity, zScore);
     Assert.assertEquals(activityId, activity.getActivityId());
 
     Assert.assertEquals(allTimeCount, activity.getAllTimeCount());
@@ -35,6 +37,12 @@ public class ActivityTest {
     Assert.assertEquals(type, activity.getActivityType());
     Assert.assertEquals(conversationId, activity.getConversationId());
     Assert.assertEquals(conversationName, activity.getConversationName());
+    Assert.assertEquals(dailyPopularity[3], activity.getPopularityToday(), 0.0001);
+    Assert.assertEquals(dailyPopularity, activity.getDailyPopularity());
+    Assert.assertEquals(zScore, activity.getZScore(), 0.0001);
+
+    activity.increaseDailyPopularity();
+    Assert.assertEquals(9, activity.getPopularityToday(), 0.0001);
 
   }
 }

--- a/src/test/java/codeu/model/data/ServerStartupTimesTest.java
+++ b/src/test/java/codeu/model/data/ServerStartupTimesTest.java
@@ -1,0 +1,126 @@
+package codeu.model.data;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.Before;
+
+
+public class ServerStartupTimesTest {
+
+  private UUID serverStartupTimesId;
+
+  /** The current time as an Instant */
+  private Instant currentTime;
+
+  /** 1 year before five days after current date */
+  private Instant oneYearFiveDaysBefore;
+
+  /** 25 hours before currentTime */
+  private Instant twentyfiveHoursBefore;
+
+  /** 24 hours before currentTime */
+  private Instant twentyfourHoursBefore;
+
+  /** 20 hours before currentTime */
+  private Instant twentyHoursBefore;
+
+  /** 25 hours after currentTime */
+  private Instant twentyfiveHoursAfter;
+
+  /** Instance of serverStartupTimes used in following tests */
+  private ServerStartupTimes serverStartupTimes;
+
+  @Before
+  public void setup() {
+
+    ZonedDateTime currentDate = ZonedDateTime.now();
+
+    currentTime = currentDate.toInstant();
+
+    oneYearFiveDaysBefore = currentDate.minusYears(1).plusDays(5).toInstant();
+
+    twentyfiveHoursBefore = currentDate.minusDays(1).toInstant();
+
+    twentyfourHoursBefore = currentDate.minusDays(1).toInstant();
+
+    twentyHoursBefore = currentDate.minusHours(20).toInstant();
+
+    twentyfiveHoursAfter = currentDate.plusHours(25).toInstant();
+
+    serverStartupTimesId = UUID.randomUUID();
+
+    Instant referenceServerStartupTime = Instant.ofEpochMilli(1000);
+    Instant currentServerStartupTime = Instant.ofEpochMilli(2000);
+    serverStartupTimes = new ServerStartupTimes(serverStartupTimesId, referenceServerStartupTime, currentServerStartupTime);
+
+  }
+
+  @Test
+  public void testCreate() {
+
+    Assert.assertEquals(serverStartupTimesId, serverStartupTimes.getServerStartupTimesId());
+    Assert.assertEquals(Instant.ofEpochMilli(1000), serverStartupTimes.getReferenceServerStartupTime());
+    Assert.assertEquals(Instant.ofEpochMilli(2000), serverStartupTimes.getCurrentServerStartupTime());
+
+  }
+
+
+  @Test
+  public void TestSetReferenceServerStartupTime() {
+
+    serverStartupTimes.setReferenceServerStartupTime(Instant.ofEpochMilli(3000));
+    Assert.assertEquals(Instant.ofEpochMilli(3000), serverStartupTimes.getReferenceServerStartupTime());
+
+  }
+
+
+  @Test
+  public void testCompareTimesOneYearBeforeFiveDaysAfter() {
+
+    serverStartupTimes.setReferenceServerStartupTime(oneYearFiveDaysBefore);
+    serverStartupTimes.setCurrentServerStartupTime(currentTime);
+    Assert.assertTrue(serverStartupTimes.compareStartupTimes24());
+
+  }
+
+  @Test
+  public void testCompareTimesTwentyfiveHoursBefore() {
+
+    serverStartupTimes.setReferenceServerStartupTime(twentyfiveHoursBefore);
+    serverStartupTimes.setCurrentServerStartupTime(currentTime);
+    Assert.assertTrue(serverStartupTimes.compareStartupTimes24());
+
+  }
+
+  @Test
+  public void testCompareTimesTwentyfourHoursBefore() {
+
+    serverStartupTimes.setReferenceServerStartupTime(twentyfourHoursBefore);
+    serverStartupTimes.setCurrentServerStartupTime(currentTime);
+    Assert.assertTrue(serverStartupTimes.compareStartupTimes24());
+
+  }
+
+  @Test
+  public void testCompareTimesTwentyHoursBefore() {
+
+    serverStartupTimes.setReferenceServerStartupTime(twentyHoursBefore);
+    serverStartupTimes.setCurrentServerStartupTime(currentTime);
+    Assert.assertFalse(serverStartupTimes.compareStartupTimes24());
+
+  }
+
+  @Test
+  public void testCompareTimesTwentyFiveHoursAfter() {
+
+    serverStartupTimes.setReferenceServerStartupTime(twentyfiveHoursAfter);
+    serverStartupTimes.setCurrentServerStartupTime(currentTime);
+    Assert.assertFalse(serverStartupTimes.compareStartupTimes24());
+
+  }
+
+
+}

--- a/src/test/java/codeu/model/store/basic/ActivityStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ActivityStoreTest.java
@@ -18,9 +18,9 @@ public class ActivityStoreTest {
   private UUID activityId = UUID.randomUUID();
   private UUID activityId2 = UUID.randomUUID();
 
-  private final Activity ACTIVITY_ONE = new Activity(activityId, 1, Instant.ofEpochMilli(1000), "activity_one", UUID.randomUUID(), "test_user1", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name");
-  private final Activity ACTIVITY_TWO = new Activity(activityId2, 2, Instant.ofEpochMilli(2000), "activity_two", UUID.randomUUID(), "test_user1", ActivityType.REGISTRATION, null, null);
-  private final Activity ACTIVITY_THREE = new Activity(UUID.randomUUID(), 3, Instant.ofEpochMilli(3000), "activity_three", UUID.randomUUID(), "test_user2", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name2");
+  private final Activity ACTIVITY_ONE = new Activity(activityId, 1, Instant.ofEpochMilli(1000), "activity_one", UUID.randomUUID(), "test_user1", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name", new double[4], 0);
+  private final Activity ACTIVITY_TWO = new Activity(activityId2, 2, Instant.ofEpochMilli(2000), "activity_two", UUID.randomUUID(), "test_user1", ActivityType.REGISTRATION, null, null, new double[4], 0);
+  private final Activity ACTIVITY_THREE = new Activity(UUID.randomUUID(), 3, Instant.ofEpochMilli(3000), "activity_three", UUID.randomUUID(), "test_user2", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name2", new double[4], 0);
 
   @Before
   public void setup() {
@@ -67,7 +67,7 @@ public class ActivityStoreTest {
   @Test
   public void testAddActivity() {
     UUID inputActivityId = UUID.randomUUID();
-    Activity inputActivity = new Activity(inputActivityId, 1, Instant.ofEpochMilli(1000), "activity_two", UUID.randomUUID(), "test_user2", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name2");
+    Activity inputActivity = new Activity(inputActivityId, 1, Instant.ofEpochMilli(1000), "activity_two", UUID.randomUUID(), "test_user2", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name2", new double[4], 0);
 
     activityStore.addActivity(inputActivity);
     Activity resultActivity = activityStore.getActivityWithId(inputActivityId);
@@ -86,5 +86,8 @@ public class ActivityStoreTest {
     Assert.assertEquals(expectedActivity.getActivityType(), actualActivity.getActivityType());
     Assert.assertEquals(expectedActivity.getConversationId(), actualActivity.getConversationId());
     Assert.assertEquals(expectedActivity.getConversationName(), actualActivity.getConversationName());
+    Assert.assertEquals(expectedActivity.getPopularityToday(), actualActivity.getPopularityToday(), 0.0001);
+    Assert.assertEquals(expectedActivity.getDailyPopularity(), actualActivity.getDailyPopularity());
+    Assert.assertEquals(expectedActivity.getZScore(), actualActivity.getZScore(), 0.0001);
   }
 }

--- a/src/test/java/codeu/model/store/basic/ServerStartupTimesStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/ServerStartupTimesStoreTest.java
@@ -1,0 +1,50 @@
+package codeu.model.store.basic;
+
+import codeu.model.data.ServerStartupTimes;
+import codeu.model.store.persistence.PersistentStorageAgent;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ServerStartupTimesStoreTest {
+  private ServerStartupTimesStore serverStartupTimesStore;
+  private PersistentStorageAgent mockPersistentStorageAgent;
+
+  private final ServerStartupTimes serverStartupTimes = new ServerStartupTimes(UUID.randomUUID(), Instant.ofEpochMilli(1000), Instant.ofEpochMilli(2000));
+
+  @Before
+  public void setup() {
+    mockPersistentStorageAgent = Mockito.mock(PersistentStorageAgent.class);
+    serverStartupTimesStore = serverStartupTimesStore.getTestInstance(mockPersistentStorageAgent);
+
+    serverStartupTimesStore.setServerStartupTimes(serverStartupTimes);
+  }
+
+  @Test
+  public void testGetServerStartupTimes() {
+    ServerStartupTimes resultServerStartupTimes = serverStartupTimesStore.getServerStartupTimes();
+
+    assertEquals(serverStartupTimes, resultServerStartupTimes);
+  }
+
+  @Test
+  public void testUpdateServerStartupTimes() {
+
+    ServerStartupTimes inputServerStartupTimes = new ServerStartupTimes(UUID.randomUUID(), Instant.ofEpochMilli(3000), Instant.ofEpochMilli(4000));
+    serverStartupTimesStore.updateServerStartupTimes(inputServerStartupTimes);
+
+    Mockito.verify(mockPersistentStorageAgent).writeThrough(inputServerStartupTimes);
+  }
+
+  private void assertEquals(ServerStartupTimes expectedServerStartupTimes, ServerStartupTimes actualServerStartupTimes) {
+    System.out.println(expectedServerStartupTimes.getServerStartupTimesId());
+    System.out.println(actualServerStartupTimes.getServerStartupTimesId());
+    Assert.assertEquals(expectedServerStartupTimes.getServerStartupTimesId(), actualServerStartupTimes.getServerStartupTimesId());
+    Assert.assertEquals(expectedServerStartupTimes.getReferenceServerStartupTime(), actualServerStartupTimes.getReferenceServerStartupTime());
+    Assert.assertEquals(expectedServerStartupTimes.getCurrentServerStartupTime(), actualServerStartupTimes.getCurrentServerStartupTime());
+
+  }
+}

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -255,7 +255,7 @@ public class PersistentDataStoreTest {
     persistentDataStore.writeThrough(inputActivityTwo);
 
     // load
-    List<Activity> resultActivities = persistentDataStore.loadActivities();
+    List<Activity> resultActivities = persistentDataStore.loadActivities(false);
 
     // confirm that what we saved matches what we loaded
     Activity resultActivityOne = resultActivities.get(0);
@@ -284,6 +284,18 @@ public class PersistentDataStoreTest {
     Assert.assertTrue(Arrays.equals(dailyPopularityTwo, resultActivityTwo.getDailyPopularity()));
     Assert.assertEquals(zScoreTwo, resultActivityTwo.getZScore(), 0.0001);
 
+    /** Test second method of loading activities, which should activate if a day has passed */
+    resultActivities = persistentDataStore.loadActivities(true);
+
+    resultActivityOne = resultActivities.get(0);
+    double[] checkArrayOne = {2, 3, 4, 0};
+    Assert.assertTrue(Arrays.equals(checkArrayOne, resultActivityOne.getDailyPopularity()));
+    Assert.assertEquals(-1.52128, resultActivityOne.getZScore(), 0.0001);
+
+    double[] checkArrayTwo = {0, 0, 0, 0};
+    resultActivityTwo = resultActivities.get(1);
+    Assert.assertTrue(Arrays.equals(checkArrayTwo, resultActivityTwo.getDailyPopularity()));
+    Assert.assertEquals(0, resultActivityTwo.getZScore(), 0.0001);
 
   }
 }

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -9,6 +9,7 @@ import codeu.model.data.ServerStartupTimes;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -231,7 +232,9 @@ public class PersistentDataStoreTest {
     ActivityType typeOne = ActivityType.CONVERSATION;
     UUID conversationIdOne = UUID.fromString("10000002-2222-3333-4444-555555555555");
     String conversationNameOne = "test conversation name one";
-    Activity inputActivityOne = new Activity(activityIdOne, allTimeCountOne, creationOne, messageOne, userUuidOne, usernameOne, typeOne, conversationIdOne, conversationNameOne);
+    double[] dailyPopularityOne = {1, 2, 3, 4};
+    double zScoreOne = -1;
+    Activity inputActivityOne = new Activity(activityIdOne, allTimeCountOne, creationOne, messageOne, userUuidOne, usernameOne, typeOne, conversationIdOne, conversationNameOne, dailyPopularityOne, zScoreOne);
 
     UUID activityIdTwo = UUID.fromString("10000003-2222-3333-4444-555555555555");
     int allTimeCountTwo = 5;
@@ -242,7 +245,10 @@ public class PersistentDataStoreTest {
     ActivityType typeTwo = ActivityType.REGISTRATION;
     UUID conversationIdTwo = null;
     String conversationNameTwo = null;
-    Activity inputActivityTwo = new Activity(activityIdTwo, allTimeCountTwo, creationTwo, messageTwo, userUuidTwo, usernameTwo, typeTwo, conversationIdTwo, conversationNameTwo);
+    double[] dailyPopularityTwo = {0, 0, 0, 0};
+    double zScoreTwo = 0;
+
+    Activity inputActivityTwo = new Activity(activityIdTwo, allTimeCountTwo, creationTwo, messageTwo, userUuidTwo, usernameTwo, typeTwo, conversationIdTwo, conversationNameTwo, dailyPopularityTwo, zScoreTwo);
 
     // save
     persistentDataStore.writeThrough(inputActivityOne);
@@ -262,6 +268,8 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(typeOne, resultActivityOne.getActivityType());
     Assert.assertEquals(conversationIdOne, resultActivityOne.getConversationId());
     Assert.assertEquals(conversationNameOne, resultActivityOne.getConversationName());
+    Assert.assertTrue(Arrays.equals(dailyPopularityOne, resultActivityOne.getDailyPopularity()));
+    Assert.assertEquals(zScoreOne, resultActivityOne.getZScore(), 0.0001);
 
     Activity resultActivityTwo = resultActivities.get(1);
     Assert.assertEquals(activityIdTwo, resultActivityTwo.getActivityId());
@@ -273,6 +281,8 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(typeTwo, resultActivityTwo.getActivityType());
     Assert.assertEquals(conversationIdTwo, resultActivityTwo.getConversationId());
     Assert.assertEquals(conversationNameTwo, resultActivityTwo.getConversationName());
+    Assert.assertTrue(Arrays.equals(dailyPopularityTwo, resultActivityTwo.getDailyPopularity()));
+    Assert.assertEquals(zScoreTwo, resultActivityTwo.getZScore(), 0.0001);
 
 
   }

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -5,6 +5,7 @@ import codeu.model.data.Message;
 import codeu.model.data.User;
 import codeu.model.data.Activity;
 import codeu.model.data.Activity.ActivityType;
+import codeu.model.data.ServerStartupTimes;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import java.time.Instant;
@@ -150,6 +151,28 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(titleTwo, resultConversationTwo.getTitle());
     Assert.assertEquals(creationTwo, resultConversationTwo.getCreationTime());
     Assert.assertEquals(privateConversationTwo, resultConversationOne.getPrivate());
+  }
+
+  @Test
+  public void testSaveAndLoadServerStartupTimes() throws PersistentDataStoreException {
+    UUID serverStartupTimesId = UUID.fromString("10000000-2222-3333-4444-555555555555");
+    Instant referenceServerStartupTime = Instant.ofEpochMilli(1000);
+    Instant currentServerStartupTime = Instant.ofEpochMilli(2000);
+
+    ServerStartupTimes inputServerStartupTimes = new ServerStartupTimes(serverStartupTimesId, referenceServerStartupTime, currentServerStartupTime);
+
+    // save
+    persistentDataStore.writeThrough(inputServerStartupTimes);
+
+
+    // load
+    ServerStartupTimes resultServerStartupTimes = persistentDataStore.loadServerStartupTimes();
+
+    // confirm that what we saved matches what we loaded
+    Assert.assertEquals(serverStartupTimesId, resultServerStartupTimes.getServerStartupTimesId());
+    Assert.assertEquals(referenceServerStartupTime, resultServerStartupTimes.getReferenceServerStartupTime());
+    Assert.assertEquals(currentServerStartupTime, resultServerStartupTimes.getCurrentServerStartupTime());
+
   }
 
   @Test

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -92,7 +92,7 @@ public class PersistentStorageAgentTest {
   @Test
   public void testWriteThroughActivity() {
     Activity activity =
-      new Activity(UUID.randomUUID(), 0, Instant.now(), "test_message", UUID.randomUUID(), "test_username", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name");
+      new Activity(UUID.randomUUID(), 0, Instant.now(), "test_message", UUID.randomUUID(), "test_username", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name", new double[4], 0);
     persistentStorageAgent.writeThrough(activity);
     Mockito.verify(mockPersistentDataStore).writeThrough(activity);
   }

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -5,6 +5,7 @@ import codeu.model.data.Message;
 import codeu.model.data.User;
 import codeu.model.data.Activity;
 import codeu.model.data.Activity.ActivityType;
+import codeu.model.data.ServerStartupTimes;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.Before;
@@ -53,6 +54,12 @@ public class PersistentStorageAgentTest {
   }
 
   @Test
+  public void testLoadServerStartupTimes() throws PersistentDataStoreException {
+    persistentStorageAgent.loadServerStartupTimes();
+    Mockito.verify(mockPersistentDataStore).loadServerStartupTimes();
+  }
+
+  @Test
   public void testWriteThroughUser() {
     User user =
         new User(
@@ -88,6 +95,13 @@ public class PersistentStorageAgentTest {
       new Activity(UUID.randomUUID(), 0, Instant.now(), "test_message", UUID.randomUUID(), "test_username", ActivityType.CONVERSATION, UUID.randomUUID(), "test_conversation_name");
     persistentStorageAgent.writeThrough(activity);
     Mockito.verify(mockPersistentDataStore).writeThrough(activity);
+  }
+
+  @Test
+  public void testWriteThroughServerStartupTimes() {
+    ServerStartupTimes serverStartupTimes = new ServerStartupTimes(UUID.randomUUID(), Instant.now(), Instant.now());
+    persistentStorageAgent.writeThrough(serverStartupTimes);
+    Mockito.verify(mockPersistentDataStore).writeThrough(serverStartupTimes);
   }
 
 }

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -48,9 +48,15 @@ public class PersistentStorageAgentTest {
   }
 
   @Test
-  public void testLoadActivities() throws PersistentDataStoreException {
-    persistentStorageAgent.loadActivities();
-    Mockito.verify(mockPersistentDataStore).loadActivities();
+  public void testLoadActivitiesTrue() throws PersistentDataStoreException {
+    persistentStorageAgent.loadActivities(true);
+    Mockito.verify(mockPersistentDataStore).loadActivities(true);
+  }
+
+  @Test
+  public void testLoadActivitiesFalse() throws PersistentDataStoreException {
+    persistentStorageAgent.loadActivities(false);
+    Mockito.verify(mockPersistentDataStore).loadActivities(false);
   }
 
   @Test


### PR DESCRIPTION
*ServerStartupTimes Class
++This class was included so that I could measure time, comparing the times between a reference point and the current time that the server was logged in to. The passing of 24 hours between these points is considered a 'day ('days' in this sense are not measured by any sort of localTime stamp, just if at least 24 hours has passed since the first user to logged into the previous 'day'.)

*Additions to PersistentDataStore
++Activities are loaded slightly differently depending on if a 'day has passed'. If a day has passed, the dailyPopularity array field of every Activity is purged of its oldest datapoint and a 0 is shifted into the "current day's" spot of the Activity's dailyPopularity array [4,5,3,10]  becomes -->  [5,3,10,0]
++If more than 24 hours has passed, only one day's worth of data will be purged from the dailyPopularity array. This pace allows the variables in the daily popularity array to stay freshly populated even if the site hasn't been used in a while.
++Some workarounds to make sure that the dailyPopularity array and zScore fields are properly shifted and written to datastore

*Additions to Activity Class
++Added additional fields to the activity class
++Added inner methods to calculate zScore and mean depending on the Activity's dailyPopularity field

*Additions to ActivityFeedServlet
++New sorting options added (and code to make sure it works in sync with searchuser)

*Additions to ActivityFeed.jsp
++4 new buttons added to sort the list of activities 

*Tests and Other Changes
++These changes broke a lot of tests, objects, and methods used throughout the code. Most of the changes here reflect the efforts to fix what was broken.
++In particular the tests added to the ServerStartupTimes utilities and the Activity class help gauge if the added functionality is functioning properly

Everything has to be cleared from the datastore before these changes go live!